### PR TITLE
Changed the cmake build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
-project(JasmineGraph)
-
+project(JasmineGraph LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 11)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -pthread")
-link_libraries('sqlite3')
-link_libraries('rdkafka')
-link_libraries('cppkafka')
-#TODO: Need to install the library separately
-include_directories("$ENV{HOME}/software/flatbuffers/include")
-include_directories("$ENV{HOME}/software/xerces/include")
-include_directories("$ENV{HOME}/software/spdlog/include")
-include_directories("$ENV{HOME}/software/jsoncpp/include")
-
-
-
 
 add_executable(JasmineGraph main.cpp src/server/JasmineGraphServer.cpp src/server/JasmineGraphServer.h src/metadb/SQLiteDBInterface.cpp
         src/util/dbutil/edgestore_generated.h src/util/dbutil/attributestore_generated.h src/util/dbutil/partedgemapstore_generated.h src/metadb/SQLiteDBInterface.h main.h src/server/JasmineGraphInstance.cpp
@@ -31,14 +18,18 @@ add_executable(JasmineGraph main.cpp src/server/JasmineGraphServer.cpp src/serve
         src/server/JasmineGraphInstanceService.cpp src/server/JasmineGraphInstanceService.h
         src/partitioner/local/RDFParser.cpp src/partitioner/local/RDFParser.h src/partitioner/stream/Partitioner.cpp src/partitioner/stream/JasmineGraphIncrementalStore.cpp)
 
-#file(GLOB_RECURSE Dir1_Sources "*.cpp")
-#add_executable(JesminGraph ${Dir1_Sources})
+target_compile_options(JasmineGraph PRIVATE -std=c++11)
 
-#target_link_libraries(JasmineGraph /usr/local/lib/libmetis.so)
+if(CMAKE_ENABLE_DEBUG)
+    message(STATUS "DEBUG enabled")
+    target_compile_options(JasmineGraph PRIVATE -g)
+endif()
+
 #TODO: Need to install the library separately
-target_link_libraries(JasmineGraph /usr/local/lib/libmetis.a)
-target_link_libraries(JasmineGraph $ENV{HOME}/software/xerces-c-3.2.2/lib/libxerces-c.so)
-target_link_libraries(JasmineGraph $ENV{HOME}/software/flatbuffers/libflatbuffers.a)
-target_link_libraries(JasmineGraph /opt/lib/libxerces-c.a)
-target_link_libraries(JasmineGraph $ENV{HOME}/software/jsoncpp/build/debug/src/lib_json/libjsoncpp.a)
-
+target_link_libraries(JasmineGraph sqlite3)
+target_link_libraries(JasmineGraph pthread)
+target_link_libraries(JasmineGraph rdkafka)
+target_link_libraries(JasmineGraph cppkafka)
+target_link_libraries(JasmineGraph flatbuffers)
+target_link_libraries(JasmineGraph xerces-c)
+find_package(spdlog CONFIG REQUIRED)

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
-cmake clean .
+if [ "$1" == "--debug" ]; then
+    cmake -DCMAKE_ENABLE_DEBUG=1 clean .
+else
+    cmake clean .
+fi
 cmake --build . --target JasmineGraph -- -j 2


### PR DESCRIPTION
This PR contains the following changes:

- Replace the `linked_libraries` with [target_link_libraries](https://cmake.org/cmake/help/v3.10/command/target_link_libraries.html#target-link-libraries) as recommended by CMake
- Removed setting `SET CMAKE_CXX_FLAGS` variable as recommended in [here](https://cliutils.gitlab.io/modern-cmake/) and many [other places](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#get-your-hands-off-cmake_cxx_flags) instead used `target_compile_options`
- Replaced `include_directories` with `target_link_libraries`, So that those libraries will be picked from installed shared library paths
- With this change, Users doesn't want to set an environment variable as HOME and point it to cloned dependencies i:e `$ENV{HOME}/software/spdlog/include`, Users could just install(make install) the dependencies to their local machines or if they already have just run the `./build.sh` to build the jasminegraph server. 