### PR TITLE
Add auto create of log file directory in the remote worker nodes

### DIFF
--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -1142,7 +1142,7 @@ void JasmineGraphServer::copyArtifactsToWorkers(std::string workerPath, std::str
 
 void JasmineGraphServer::deleteWorkerPath(std::string workerHost, std::string workerPath) {
     std::string pathDeletionCommand = "rm -rf " + workerPath;
-    char buffer[128];
+    char buffer[BUFFER_SIZE];
     std::string result = "";
 
     if (workerHost.find("localhost") == std::string::npos) {
@@ -1155,7 +1155,7 @@ void JasmineGraphServer::deleteWorkerPath(std::string workerHost, std::string wo
     if (input) {
         // read the input
         while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
+            if (fgets(buffer, BUFFER_SIZE, input) != NULL) {
                 result.append(buffer);
             }
         }
@@ -1168,7 +1168,7 @@ void JasmineGraphServer::deleteWorkerPath(std::string workerHost, std::string wo
 
 void JasmineGraphServer::createWorkerPath(std::string workerHost, std::string workerPath) {
     std::string pathCreationCommand = "mkdir -p " + workerPath;
-    char buffer[128];
+    char buffer[BUFFER_SIZE];
     std::string result = "";
 
     if (workerHost.find("localhost") == std::string::npos) {
@@ -1181,7 +1181,7 @@ void JasmineGraphServer::createWorkerPath(std::string workerHost, std::string wo
     if (input) {
         // read the input
         while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
+            if (fgets(buffer, BUFFER_SIZE, input) != NULL) {
                 result.append(buffer);
             }
         }
@@ -1194,7 +1194,7 @@ void JasmineGraphServer::createWorkerPath(std::string workerHost, std::string wo
 
 void JasmineGraphServer::createLogFilePath(std::string workerHost, std::string workerPath) {
     std::string pathCreationCommand = "mkdir -p " + workerPath + "/logs";
-    char buffer[128];
+    char buffer[BUFFER_SIZE];
     std::string result = "";
 
     if (workerHost.find("localhost") == std::string::npos) {
@@ -1207,12 +1207,12 @@ void JasmineGraphServer::createLogFilePath(std::string workerHost, std::string w
     if (input) {
         // read the input
         while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
+            if (fgets(buffer, BUFFER_SIZE, input) != NULL) {
                 result.append(buffer);
             }
         }
         if (!result.empty()) {
-            server_logger.log("Error executing command for creating worker path : " + result, "error");
+            server_logger.log("Error executing command for creating log file path : " + result, "error");
         }
         pclose(input);
     }

--- a/src/server/JasmineGraphServer.h
+++ b/src/server/JasmineGraphServer.h
@@ -31,6 +31,7 @@ private:
     std::string profile;
     std::string workerHosts;
     int numberOfWorkers;
+    static const int BUFFER_SIZE = 128;
     int serverPort;
     int serverDataPort;
     std::map<std::string, std::vector<int>> workerPortsMap;

--- a/src/server/JasmineGraphServer.h
+++ b/src/server/JasmineGraphServer.h
@@ -46,6 +46,7 @@ private:
 
     static void copyArtifactsToWorkers(std::string workerPath, std::string artifactLocation, std::string remoteWorker);
     static void createWorkerPath (std::string workerHost, std::string workerPath);
+    static void createLogFilePath (std::string workerHost, std::string workerPath);
     static void deleteWorkerPath (std::string workerHost, std::string workerPath);
 
     static bool hasEnding(std::string const &fullString, std::string const &ending);


### PR DESCRIPTION
When starting up the workers only the essential artifacts to start workers are getting exported by the master. That doesn't include the logs directory. This commit enables
creating the logs directory in the remote workers so that the workers are getting started without an issue.