### PR TITLE
Docker file updated to change the metis path configuration inside the…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
     sed -i '/target_link_libraries(JasmineGraph $ENV{HOME}\/software\/xerces-c-3.2.2\/lib\/libxerces-c.so)/c\#target_link_libraries(JasmineGraph $ENV{HOME}\/software\/xerces-c-3.2.2\/lib\/libxerces-c.so)' CMakeLists.txt && \
     sed -i '/target_link_libraries(JasmineGraph \/opt\/lib\/libxerces-c.a)/c\#target_link_libraries(JasmineGraph \/opt\/lib\/libxerces-c.a)' CMakeLists.txt && \
     sed -i '/target_link_libraries(JasmineGraph $ENV{HOME}\/software\/cppkafka\/build\/usr\/local\/lib\/libcppkafka.so)/c\target_link_libraries(JasmineGraph \/usr\/local\/lib\/libcppkafka.so)' CMakeLists.txt && \
-    sed -i '/namespace JasminGraph.Edgestore;/c\namespace JasmineGraph.Edgestore;' src/util/dbutil/edgestore.fbs
+    sed -i '/namespace JasminGraph.Edgestore;/c\namespace JasmineGraph.Edgestore;' src/util/dbutil/edgestore.fbs && \
+    sed -i '/org.jasminegraph.partitioner.metis.bin=home\/ubuntu\/software\/metis-5.1.0\/bin/c\org.jasminegraph.partitioner.metis.bin=home\/ubuntu\/software\/metis\/metis-5.1.0\/bin' conf/jasminegraph-server.properties
 WORKDIR /home/ubuntu/software/flatbuffers
 RUN ./flatc --cpp -o /home/ubuntu/software/jasminegraph/src/util/dbutil /home/ubuntu/software/jasminegraph/src/util/dbutil/edgestore.fbs && \
     ./flatc --cpp -o /home/ubuntu/software/jasminegraph/src/util/dbutil /home/ubuntu/software/jasminegraph/src/util/dbutil/attributestore.fbs && \


### PR DESCRIPTION
… docker image correctly

There is a difference in between the paths where the metis library gets installed in docker and native profiles. In the source code we keep the configuration for the native
mode and when it is using docker this change will update the configuration to work with docker profile