### PR TITLE
central store transfer logic changes for triangle count algorithm

### DIFF
--- a/src/frontend/JasmineGraphFrontEnd.h
+++ b/src/frontend/JasmineGraphFrontEnd.h
@@ -53,7 +53,7 @@ public:
 
     static void removeGraph(std::string graphID, SQLiteDBInterface sqlite, std::string masterIP);
 
-    static std::string copyCentralStoreToAggregator(std::string aggregatorHostName, std::string aggregatorPort, std::string host, std::string port, int graphId, int partitionId, std::string masterIP);
+    static std::string copyCentralStoreToAggregator(std::string aggregatorHostName, std::string aggregatorPort, std::string aggregatorDataPort, int graphId, int partitionId, std::string masterIP);
 
     static std::vector<std::vector<string>> getWorkerCombination (SQLiteDBInterface sqlite, std::string graphId);
 

--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -1147,7 +1147,6 @@ void JasmineGraphServer::copyCentralStoreToAggregateLocation(std::string filePat
 
     std::string fullFileName = aggregatorFilePath + "/" + fileName;
 
-    utils.unzipFile(fullFileName);
 }
 
 bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, int dataPort, int graphID,


### PR DESCRIPTION
In the existing implementation it uses scp to transfer central stores between workers. But this fails when it comes to docker version.
This change will use the existing file transfer service to transfer central stores between workers.