### PR TITLE
Docker volume Mount of log directories in worker nodes into the worker instance directory

### DIFF
--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -305,9 +305,10 @@ void JasmineGraphServer::startRemoteWorkers(std::vector<int> workerPortsVector, 
     } else if (profile == "docker") {
         for (int i =0 ; i < workerPortsVector.size() ; i++) {
             if (masterHost == host || host == "localhost") {
-                serverStartScript = "docker run -v" + instanceDataFolder + ":" + instanceDataFolder +
+                serverStartScript = "docker run -v " + instanceDataFolder + ":" + instanceDataFolder +
                                     " -v " + aggregateDataFolder + ":" + aggregateDataFolder +
-                                    " -v " + nmonFileLocation + ":" + nmonFileLocation + " -p " +
+                                    " -v " + nmonFileLocation + ":" + nmonFileLocation +
+                                    " -v " + instanceDataFolder + "/" + to_string(i) + "/logs" + ":" + "/home/ubuntu/software/jasminegraph/logs" + " -p " +
                                     std::to_string(workerPortsVector.at(i)) + ":" +
                                     std::to_string(workerPortsVector.at(i)) + " -p " +
                                     std::to_string(workerDataPortsVector.at(i)) + ":" +
@@ -318,7 +319,8 @@ void JasmineGraphServer::startRemoteWorkers(std::vector<int> workerPortsVector, 
             } else {
                 serverStartScript = "docker -H ssh://" + host + " run -v " + instanceDataFolder + ":" + instanceDataFolder +
                                     " -v " + aggregateDataFolder + ":" + aggregateDataFolder +
-                                    " -v "+ nmonFileLocation + ":" + nmonFileLocation+ " -p " +
+                                    " -v " + nmonFileLocation + ":" + nmonFileLocation +
+                                    " -v " + instanceDataFolder + "/" + to_string(i) + "/logs" + ":" + "/home/ubuntu/software/jasminegraph/logs" + " -p " +
                                     std::to_string(workerPortsVector.at(i)) + ":" +
                                     std::to_string(workerPortsVector.at(i)) + " -p " +
                                     std::to_string(workerDataPortsVector.at(i)) + ":" +


### PR DESCRIPTION
When using jasminegraph docker version, we do not have access to the log files of worker instances. This PR contains the fix to mount the worker log directories into the instance directory mount of the host machine.