### PR TITLE
Fix docker build is failing only after merging pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{github.head_ref}}
         fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
     - name: Build
       # Build JasmineGraph docker image
       run: docker build -t jasminegraph .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 env:
   # Customize the build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -12,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+      with:
+        ref: ${{github.head_ref}}
+        fetch-depth: 0
     - name: Build
       # Build JasmineGraph docker image
-      run: |
-        cd docker
-        docker build -t jasminegraph .
+      run: docker build -t jasminegraph .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM miyurud/jasminegraph
 WORKDIR /home/ubuntu/software
 RUN apt-get update
-RUN git clone https://github.com/miyurud/jasminegraph.git
+COPY . jasminegraph/
 ENV HOME="/home/ubuntu"
 RUN mkdir -p /var/tmp/nmon
 WORKDIR /home/ubuntu/software/jasminegraph


### PR DESCRIPTION
In `Dockerfile` the docker image is built by cloning the repository itself and it will get the `master` branch of the repository. If the `master` branch build is passing all the pull requests will be automatically passed as the changes done in pull request won't affect for the build. Build will start failing only after merging the pull request.
With these changes docker image will be built from the source code itself in the pull request.

PS:
* The base of this pull request is the commit before merging the last pull request. ( Which cause the build failure )
* Enabled workflow builds on push or pull request to the master branch to get rid of unnecessary workflow runs