### PR TITLE
Revert back to python 3.8 to support StellarGraph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ add_executable(JasmineGraph main.cpp src/server/JasmineGraphServer.cpp src/serve
         src/frontend/core/factory/ExecutorFactory.cpp src/frontend/core/factory/ExecutorFactory.h src/frontend/core/CoreConstants.cpp
         src/frontend/core/CoreConstants.h)
 
-target_compile_options(JasmineGraph PRIVATE -std=c++11 -I/usr/include/python3.11)
+target_compile_options(JasmineGraph PRIVATE -std=c++11 -I/usr/include/python3.8)
 
 if(CMAKE_ENABLE_DEBUG)
     message(STATUS "DEBUG enabled")
@@ -59,9 +59,9 @@ target_link_libraries(JasmineGraph /usr/lib/x86_64-linux-gnu/libflatbuffers.a)
 target_link_libraries(JasmineGraph /usr/lib/x86_64-linux-gnu/libjsoncpp.so)
 target_link_libraries(JasmineGraph /usr/local/lib/libcppkafka.so)
 
-set(PYTHON_EXECUTABLE "/usr/bin/python3.11")
-set(PYTHON_INCLUDE_DIR "/usr/include/python3.11m")
-set(PYTHON_LIBRARIES "/usr/lib/x86_64-linux-gnu/libpython3.11.so")
+set(PYTHON_EXECUTABLE "/usr/bin/python3.8")
+set(PYTHON_INCLUDE_DIR "/usr/include/python3.8m")
+set(PYTHON_LIBRARIES "/usr/lib/x86_64-linux-gnu/libpython3.8.so")
 
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${PYTHON_DIRECTORIES})


### PR DESCRIPTION
Revert back from Python 3.11 to python 3.8 to support StellarGraph.