### PR TITLE
Enable Style Checks

### DIFF
--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -12,14 +12,24 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
+            - name: Install tools
+              run: |
+                sudo apt-get update && sudo apt-get install -y --no-install-recommends cpplint shfmt
+                sudo wget https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 -O /bin/hadolint && sudo chmod +x /bin/hadolint
+                pip install install pylint
+
             - name: cpplint check
               if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip cpplint Check')}}
-              run: |
-                sudo apt-get install cpplint
-                cpplint --linelength=120 --filter=-build,-runtime,-readability/todo,-whitespace/todo,-readability/casting,-readability/braces,-readability/fn_size,-legal/copyright --exclude=./src/util/sqlite3/ --recursive .
+              run: cpplint --linelength=120 --filter=-build,-runtime,-readability/todo,-whitespace/todo,-readability/casting,-readability/braces,-readability/fn_size,-legal/copyright --exclude=./src/util/sqlite3/ --recursive .
 
             - name: pylint check
               if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip pylint Check')}}
-              run: |
-                pip install install pylint
-                pylint --recursive=y .
+              run: pylint --recursive=y .
+            
+            - name: hadolint check
+              if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip hadolint Check')}}
+              run: find . -type f -name '*Dockerfile*' -print0 | xargs -0 hadolint --ignore DL3008 --ignore DL3041 -t warning
+
+            - name: shfmt check
+              if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip shfmt Check')}}
+              run: find . -type f -name '*.sh' -print0 | xargs -0 shfmt -d -s -i 4 -ci

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -12,7 +12,14 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - run: sudo apt-get install cpplint
             - name: cpplint check
               if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip cpplint Check')}}
-              run: cpplint --linelength=120 --filter=-build,-runtime,-readability/todo,-whitespace/todo,-readability/casting,-readability/braces,-readability/fn_size,-legal/copyright --exclude=./src/util/sqlite3/ --recursive .
+              run: |
+                sudo apt-get install cpplint
+                cpplint --linelength=120 --filter=-build,-runtime,-readability/todo,-whitespace/todo,-readability/casting,-readability/braces,-readability/fn_size,-legal/copyright --exclude=./src/util/sqlite3/ --recursive .
+
+            - name: pylint check
+              if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip pylint Check')}}
+              run: |
+                pip install install pylint
+                pylint --recursive=y .

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -1,0 +1,18 @@
+name: Style Check
+
+on:
+    push:
+      branches: [master]
+    pull_request:
+      branches: [master]
+
+jobs:
+    style-check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - run: sudo apt-get install cpplint
+            - name: cpplint check
+              if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip cpplint Check')}}
+              run: cpplint --linelength=120 --filter=-build,-runtime,-readability/todo,-whitespace/todo,-readability/casting,-readability/braces,-readability/fn_size,-legal/copyright --exclude=./src/util/sqlite3/ --recursive .

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -28,7 +28,7 @@ jobs:
             
             - name: hadolint check
               if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip hadolint Check')}}
-              run: find . -type f -name '*Dockerfile*' -print0 | xargs -0 hadolint --ignore DL3008 --ignore DL3041 -t warning
+              run: find . -type f -name '*Dockerfile*' -print0 | xargs -0 hadolint --ignore DL3008 -t warning
 
             - name: shfmt check
               if: ${{!contains(github.event.pull_request.labels.*.name, 'Skip shfmt Check')}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM miyurud/jasminegraph
+FROM miyurud/jasminegraph:20230909T110050
 ENV HOME="/home/ubuntu"
 ENV JASMINEGRAPH_HOME="/home/ubuntu/software/jasminegraph"
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,77 +1,66 @@
 #!/usr/bin/env bash
 
-
 MODE=${MODE}
 MASTERIP=${MASTERIP}
 WORKERS=${WORKERS}
 WORKERIP=${WORKERIP}
 HOST_NAME=${HOST_NAME}
-SERVER_PORT=${SERVER_PORT};
-SERVER_DATA_PORT=${SERVER_DATA_PORT};
+SERVER_PORT=${SERVER_PORT}
+SERVER_DATA_PORT=${SERVER_DATA_PORT}
 ENABLE_NMON=${ENABLE_NMON}
 
 while [ $# -gt 0 ]; do
 
-   if [[ $1 == *"--"* ]]; then
+    if [[ $1 == *"--"* ]]; then
         param="${1/--/}"
         declare $param="$2"
         echo $1 $2 // Optional to see the parameter:value result
-   fi
+    fi
 
-  shift
+    shift
 done
 
-if [ -z "$MODE" ] ;
-then
+if [ -z "$MODE" ]; then
     echo "MODE OF OPERATION SHOULD BE SPECIFIED"
     echo "Use argument 1 <MASTERIP> <NUMBER OF WORKERS> <WORKER IPS> to start JasmineGraph in Master mode."
     echo "Use 2 <hostName> <serverPort> <serverDataPort> to start in Worker mode."
     exit 1
 fi
 
-if [ $MODE -eq 1 ] ;
-then
-    if [ -z "$MASTERIP" ] ;
-        then
-            echo "MASTER IP SHOULD BE SPECIFIED"
-            exit 1
+if [ $MODE -eq 1 ]; then
+    if [ -z "$MASTERIP" ]; then
+        echo "MASTER IP SHOULD BE SPECIFIED"
+        exit 1
     fi
 
-    if [ -z "$WORKERS" ] ;
-        then
-            echo "Number of workers SHOULD BE SPECIFIED"
-            exit 1
+    if [ -z "$WORKERS" ]; then
+        echo "Number of workers SHOULD BE SPECIFIED"
+        exit 1
     fi
 
-    if [ -z "$WORKERIP" ] ;
-        then
-            echo "Worker IPs SHOULD BE SPECIFIED"
-            exit 1
+    if [ -z "$WORKERIP" ]; then
+        echo "Worker IPs SHOULD BE SPECIFIED"
+        exit 1
     fi
 else
-
-    if [ -z "$MASTERIP" ] ;
-         then
-             echo "MASTER IP SHOULD BE SPECIFIED"
-             exit 1
+    if [ -z "$MASTERIP" ]; then
+        echo "MASTER IP SHOULD BE SPECIFIED"
+        exit 1
     fi
 
-    if [ -z "$SERVER_PORT" ] ;
-        then
-            echo "SERVER PORT SHOULD BE SPECIFIED"
-            exit 1
+    if [ -z "$SERVER_PORT" ]; then
+        echo "SERVER PORT SHOULD BE SPECIFIED"
+        exit 1
     fi
 
-    if [ -z "$SERVER_DATA_PORT" ] ;
-        then
-            echo "SERVER DATA PORT SHOULD BE SPECIFIED"
-            exit 1
+    if [ -z "$SERVER_DATA_PORT" ]; then
+        echo "SERVER DATA PORT SHOULD BE SPECIFIED"
+        exit 1
     fi
 fi
 
 export LD_LIBRARY_PATH=/usr/local/lib
-if [ $MODE -eq 1 ] ;
-then
+if [ $MODE -eq 1 ]; then
     ./JasmineGraph "docker" $MODE $MASTERIP $WORKERS $WORKERIP $ENABLE_NMON
 else
     ./JasmineGraph "docker" $MODE $HOST_NAME $MASTERIP $SERVER_PORT $SERVER_DATA_PORT $ENABLE_NMON

--- a/run.sh
+++ b/run.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 
-JASMINEGRAPH_DIR="`dirname \"$0\"`"
-PROFILE=$1;
-MODE=$2;
+JASMINEGRAPH_DIR="$(dirname \"$0\")"
+PROFILE=$1
+MODE=$2
 
-JASMINEGRAPH_DIR="`( cd \"$JASMINEGRAPH_DIR\" && pwd )`"
-if [ -z "$JASMINEGRAPH_DIR" ] ;
-then
-    exit 1  # fail
+JASMINEGRAPH_DIR="$(cd \"$JASMINEGRAPH_DIR\" && pwd)"
+if [ -z "$JASMINEGRAPH_DIR" ]; then
+    exit 1 # fail
 fi
 
 export JASMINEGRAPH_HOME="$JASMINEGRAPH_DIR"
 
-if [ -z "$MODE" ] ;
-then
+if [ -z "$MODE" ]; then
     echo "MODE OF OPERATION SHOULD BE SPECIFIED"
     echo "Use argument 1 to start JasmineGraph in Master mode."
     echo "Use 2 <hostName> <serverPort> <serverDataPort> to start in Worker mode."
@@ -22,33 +20,29 @@ fi
 
 cd $JASMINEGRAPH_DIR
 
-if [ $MODE -eq 1 ] ;
-then
+if [ $MODE -eq 1 ]; then
     echo "STARTING MASTER MODE"
 
-    MASTER_HOST_NAME=$3;
-    NUMBER_OF_WORKERS=$4;
-    WORKER_IPS=$5;
+    MASTER_HOST_NAME=$3
+    NUMBER_OF_WORKERS=$4
+    WORKER_IPS=$5
 
     ./JasmineGraph "native" $MODE $MASTER_HOST_NAME $NUMBER_OF_WORKERS $WORKER_IPS "false"
 else
-    WORKER_HOST=$3;
-    MASTER_HOST_NAME=$4;
-    SERVER_PORT=$5;
-    SERVER_DATA_PORT=$6;
+    WORKER_HOST=$3
+    MASTER_HOST_NAME=$4
+    SERVER_PORT=$5
+    SERVER_DATA_PORT=$6
 
-    if [ -z "$SERVER_PORT" ] ;
-    then
+    if [ -z "$SERVER_PORT" ]; then
         echo "SERVER PORT SHOULD BE SPECIFIED"
         exit 1
     fi
 
-    if [ -z "$SERVER_DATA_PORT" ] ;
-        then
-            echo "SERVER DATA PORT SHOULD BE SPECIFIED"
-            exit 1
+    if [ -z "$SERVER_DATA_PORT" ]; then
+        echo "SERVER DATA PORT SHOULD BE SPECIFIED"
+        exit 1
     fi
 
     ./JasmineGraph "native" $MODE $WORKER_HOST $MASTER_HOST_NAME $SERVER_PORT $SERVER_DATA_PORT "false"
 fi
-

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -6,7 +6,7 @@ TIMEOUT_SECONDS=600
 RUN_ID="$(date +%y%m%d_%H%M%S)"
 LOG_DIR="${PROJECT_ROOT}/logs/${RUN_ID}"
 while [ -d "$LOG_DIR"]; do
-    tmp_id="$((${tmp_id}+1))"
+    tmp_id="$((tmp_id + 1))"
     new_run="${RUN_ID}_${tmp_id}"
     LOG_DIR="${PROJECT_ROOT}/logs/${RUN_ID}"
 done
@@ -19,16 +19,15 @@ BUILD_LOG="${LOG_DIR}/build.log"
 RUN_LOG="${LOG_DIR}/run_master.log"
 TEST_LOG="${LOG_DIR}/test.log"
 
-
-stop_and_remove_containers () {
+stop_and_remove_containers() {
     if [ "$(docker ps -q)" ]; then
-       docker ps -a -q | xargs docker rm -f &>/dev/null
+        docker ps -a -q | xargs docker rm -f &>/dev/null
     else
         echo "No containers to stop and remove."
-    fi    
+    fi
 }
 
-build_and_run_docker () {
+build_and_run_docker() {
     stop_and_remove_containers
     cd "$PROJECT_ROOT"
     docker build -t jasminegraph:test . |& tee "$BUILD_LOG"


### PR DESCRIPTION
This PR introduces a workflow to enable style checks in code base. 
Following are the linters used.
* C/C++ - cpplint
* Python - pylint
* Dockerfile - hadolint
* Shell - shfmt

Each check can be skipped by adding the labels with `Skip <linter-name> Check`