### PR TITLE
Convert `Utils` methods to static

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,6 @@ void fnExit3(void) {
 
 int main(int argc, char *argv[]) {
     atexit(fnExit3);
-    Utils utils;
 
     if (argc <= 1) {
         main_logger.log(
@@ -47,7 +46,7 @@ int main(int argc, char *argv[]) {
     std::cout << argc << std::endl;
 
     int mode = atoi(argv[2]);
-    std::string JASMINEGRAPH_HOME = utils.getJasmineGraphHome();
+    std::string JASMINEGRAPH_HOME = Utils::getJasmineGraphHome();
     std::string profile = argv[1];  // This can be either "docker" or "native"
     std::string enableNmon = "false";
 

--- a/src/backend/JasmineGraphBackend.cpp
+++ b/src/backend/JasmineGraphBackend.cpp
@@ -20,7 +20,6 @@ limitations under the License.
 
 using namespace std;
 
-Utils utils;
 Logger backend_logger;
 
 void *backendservicesesion(void *dummyPt) {
@@ -37,7 +36,7 @@ void *backendservicesesion(void *dummyPt) {
 
         string line(data);
         backend_logger.log("Command received: " + line, "info");
-        line = utils.trim_copy(line, " \f\n\r\t\v");
+        line = Utils::trim_copy(line, " \f\n\r\t\v");
 
         if (line.compare(EXIT_BACKEND) == 0) {
             write(connFd, EXIT_ACK.c_str(), EXIT_ACK.size());
@@ -51,8 +50,7 @@ void *backendservicesesion(void *dummyPt) {
             bzero(host, 301);
             read(connFd, host, 300);
             string hostname(host);
-            Utils utils;
-            hostname = utils.trim_copy(hostname, " \f\n\r\t\v");
+            hostname = Utils::trim_copy(hostname, " \f\n\r\t\v");
             write(connFd, HOST_OK.c_str(), HOST_OK.size());
             backend_logger.log("Hostname of the worker: " + hostname, "info");
 

--- a/src/centralstore/JasmineGraphHashMapCentralStore.cpp
+++ b/src/centralstore/JasmineGraphHashMapCentralStore.cpp
@@ -28,9 +28,7 @@ JasmineGraphHashMapCentralStore::JasmineGraphHashMapCentralStore(int graphId, in
     this->graphId = graphId;
     this->partitionId = partitionId;
 
-    Utils utils;
-
-    instanceDataFolderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    instanceDataFolderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
 }
 
 bool JasmineGraphHashMapCentralStore::loadGraph() {

--- a/src/centralstore/JasmineGraphHashMapDuplicateCentralStore.cpp
+++ b/src/centralstore/JasmineGraphHashMapDuplicateCentralStore.cpp
@@ -23,9 +23,7 @@ JasmineGraphHashMapDuplicateCentralStore::JasmineGraphHashMapDuplicateCentralSto
     this->graphId = graphId;
     this->partitionId = partitionId;
 
-    Utils utils;
-
-    instanceDataFolderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    instanceDataFolderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
 }
 
 bool JasmineGraphHashMapDuplicateCentralStore::loadGraph() {

--- a/src/centralstore/incremental/NodeManager.cpp
+++ b/src/centralstore/incremental/NodeManager.cpp
@@ -30,10 +30,9 @@ std::mutex lockEdgeAdd;
 NodeManager::NodeManager(GraphConfig gConfig) {
     this->graphID = gConfig.graphID;
     this->partitionID = gConfig.partitionID;
-    Utils utils;
 
     std::string instanceDataFolderLocation =
-        utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string graphPrefix = instanceDataFolderLocation + "/g" + std::to_string(graphID);
     std::string dbPrefix = graphPrefix + "_p" + std::to_string(partitionID);
     std::string nodesDBPath = dbPrefix + "_nodes.db";

--- a/src/frontend/JasmineGraphFrontEnd.cpp
+++ b/src/frontend/JasmineGraphFrontEnd.cpp
@@ -1460,7 +1460,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                     frontend_logger.log("Error writing to socket", "error");
                 }
 
-                char predict_data[300];
+                char predict_data[301];
                 bzero(predict_data, 301);
                 string graphID = "";
                 string modelID = "";
@@ -1492,7 +1492,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 if (result_wr < 0) {
                     frontend_logger.log("Error writing to socket", "error");
                 }
-                char predict_data[300];
+                char predict_data[301];
                 bzero(predict_data, 301);
                 string graphID = "";
                 string path = "";

--- a/src/frontend/JasmineGraphFrontEnd.cpp
+++ b/src/frontend/JasmineGraphFrontEnd.cpp
@@ -108,14 +108,13 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
     frontend_logger.log("Master IP: " + masterIP, "info");
     char data[FRONTEND_DATA_LENGTH + 1];
     bzero(data, FRONTEND_DATA_LENGTH + 1);
-    Utils utils;
-    vector<Utils::worker> workerList = utils.getWorkerList(sqlite);
+    vector<Utils::worker> workerList = Utils::getWorkerList(sqlite);
     vector<DataPublisher *> workerClients;
 
     //  Initiate Thread
     thread input_stream_handler;
     //  Initiate kafka consumer parameters
-    std::string partitionCount = utils.getJasmineGraphProperty("org.jasminegraph.server.npartitions");
+    std::string partitionCount = Utils::getJasmineGraphProperty("org.jasminegraph.server.npartitions");
     int numberOfPartitions = std::stoi(partitionCount);
     std::string kafka_server_IP;
     cppkafka::Configuration configs;
@@ -156,8 +155,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             break;
         }
 
-        Utils utils;
-        line = utils.trim_copy(line, " \f\n\r\t\v");
+        line = Utils::trim_copy(line, " \f\n\r\t\v");
 
         if (currentFESession > 1) {
             canCalibrate = false;
@@ -251,8 +249,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             string uploadStartTime = ctime(&time);
             string gData(graph_data);
 
-            Utils utils;
-            gData = utils.trim_copy(gData, " \f\n\r\t\v");
+            gData = Utils::trim_copy(gData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + gData, "info");
 
             std::vector<std::string> strArr = Utils::split(gData, '|');
@@ -270,7 +267,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
 
-            if (utils.fileExists(path)) {
+            if (Utils::fileExists(path)) {
                 frontend_logger.log("Path exists", "info");
 
                 string sqlStatement =
@@ -286,15 +283,15 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 MetisPartitioner *metisPartitioner = new MetisPartitioner(&sqlite);
                 vector<std::map<int, string>> fullFileList;
                 string input_file_path =
-                    utils.getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID) + "/" + to_string(newGraphID);
+                    Utils::getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID) + "/" + to_string(newGraphID);
                 metisPartitioner->loadDataSet(input_file_path, newGraphID);
 
                 metisPartitioner->constructMetisFormat(Conts::GRAPH_TYPE_RDF);
                 fullFileList = metisPartitioner->partitioneWithGPMetis("");
                 JasmineGraphServer *jasmineServer = new JasmineGraphServer();
                 jasmineServer->uploadGraphLocally(newGraphID, Conts::GRAPH_WITH_ATTRIBUTES, fullFileList, masterIP);
-                utils.deleteDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
-                utils.deleteDirectory("/tmp/" + std::to_string(newGraphID));
+                Utils::deleteDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
+                Utils::deleteDirectory("/tmp/" + std::to_string(newGraphID));
                 JasmineGraphFrontEnd::getAndUpdateUploadTime(to_string(newGraphID), sqlite);
             } else {
                 frontend_logger.log("Graph data file does not exist on the specified path", "error");
@@ -329,8 +326,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             string uploadStartTime = ctime(&time);
             string gData(graph_data);
 
-            Utils utils;
-            gData = utils.trim_copy(gData, " \f\n\r\t\v");
+            gData = Utils::trim_copy(gData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + gData, "info");
 
             std::vector<std::string> strArr = Utils::split(gData, '|');
@@ -352,7 +348,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
 
-            if (utils.fileExists(path)) {
+            if (Utils::fileExists(path)) {
                 frontend_logger.log("Path exists", "info");
 
                 string sqlStatement =
@@ -377,7 +373,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 }
                 frontend_logger.log("Upload done", "info");
                 jasmineServer->uploadGraphLocally(newGraphID, Conts::GRAPH_TYPE_NORMAL, fullFileList, masterIP);
-                utils.deleteDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
+                Utils::deleteDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
                 string workerCountQuery = "select count(*) from worker";
                 std::vector<vector<pair<string, string>>> results = sqlite.runSelect(workerCountQuery);
                 string workerCount = results[0][0].second;
@@ -415,8 +411,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             string uploadStartTime = ctime(&time);
             string gData(graph_data);
 
-            Utils utils;
-            gData = utils.trim_copy(gData, " \f\n\r\t\v");
+            gData = Utils::trim_copy(gData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + gData, "info");
 
             std::vector<std::string> strArr = Utils::split(gData, '|');
@@ -434,10 +429,10 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
 
-            if (utils.fileExists(path)) {
+            if (Utils::fileExists(path)) {
                 frontend_logger.log("Path exists", "info");
-                std::string toDir = utils.getJasmineGraphProperty("org.jasminegraph.server.modelDir");
-                utils.copyToDirectory(path, toDir);
+                std::string toDir = Utils::getJasmineGraphProperty("org.jasminegraph.server.modelDir");
+                Utils::copyToDirectory(path, toDir);
 
                 string sqlStatement =
                     "INSERT INTO model (name,upload_path,upload_time,model_status_idmodel_status"
@@ -507,7 +502,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             bzero(type, FRONTEND_GRAPH_TYPE_LENGTH + 1);
             read(connFd, type, FRONTEND_GRAPH_TYPE_LENGTH);
             string graphType(type);
-            graphType = utils.trim_copy(graphType, " \f\n\r\t\v");
+            graphType = Utils::trim_copy(graphType, " \f\n\r\t\v");
 
             std::unordered_set<std::string> s = {"1", "2", "3"};
             if (s.find(graphType) == s.end()) {
@@ -553,8 +548,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             string uploadStartTime = ctime(&time);
             string gData(graph_data);
 
-            Utils utils;
-            gData = utils.trim_copy(gData, " \f\n\r\t\v");
+            gData = Utils::trim_copy(gData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + gData, "info");
 
             std::vector<std::string> strArr = Utils::split(gData, '|');
@@ -582,7 +576,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
 
-            if (utils.fileExists(edgeListPath) && utils.fileExists(attributeListPath)) {
+            if (Utils::fileExists(edgeListPath) && Utils::fileExists(attributeListPath)) {
                 std::cout << "Paths exists" << endl;
 
                 string sqlStatement =
@@ -608,8 +602,8 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 // Graph type should be changed to identify graphs with attributes
                 // because this graph type has additional attribute files to be uploaded
                 jasmineServer->uploadGraphLocally(newGraphID, Conts::GRAPH_WITH_ATTRIBUTES, fullFileList, masterIP);
-                utils.deleteDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
-                utils.deleteDirectory("/tmp/" + std::to_string(newGraphID));
+                Utils::deleteDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/" + to_string(newGraphID));
+                Utils::deleteDirectory("/tmp/" + std::to_string(newGraphID));
                 JasmineGraphFrontEnd::getAndUpdateUploadTime(to_string(newGraphID), sqlite);
                 result_wr = write(connFd, DONE.c_str(), DONE.size());
                 if (result_wr < 0) {
@@ -628,7 +622,6 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
         } else if (line.compare(ADD_STREAM_KAFKA) == 0) {
-            Utils utils;
             string msg_1 = "DO you want to use default KAFKA consumer(y/n) ? ";
             int result_wr_1 = write(connFd, msg_1.c_str(), msg_1.length());
             if (result_wr_1 < 0) {
@@ -648,13 +641,13 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             bzero(user_res, FRONTEND_DATA_LENGTH + 1);
             read(connFd, user_res, FRONTEND_DATA_LENGTH);
             string user_res_s(user_res);
-            user_res_s = utils.trim_copy(user_res_s, " \f\n\r\t\v");
+            user_res_s = Utils::trim_copy(user_res_s, " \f\n\r\t\v");
             for (char &c : user_res_s) {
                 c = tolower(c);
             }
             //          use default kafka consumer details
             if (user_res_s == "y") {
-                kafka_server_IP = utils.getJasmineGraphProperty("org.jasminegraph.server.streaming.kafka.host");
+                kafka_server_IP = Utils::getJasmineGraphProperty("org.jasminegraph.server.streaming.kafka.host");
                 configs = {{"metadata.broker.list", kafka_server_IP}, {"group.id", "knnect"}};
             } else {
                 // user need to start relevant kafka cluster using relevant IP address
@@ -678,15 +671,15 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 bzero(file_path, FRONTEND_DATA_LENGTH + 1);
                 read(connFd, file_path, FRONTEND_DATA_LENGTH);
                 string file_path_s(file_path);
-                file_path_s = utils.trim_copy(file_path_s, " \f\n\r\t\v");
+                file_path_s = Utils::trim_copy(file_path_s, " \f\n\r\t\v");
                 // reading kafka_server IP from the given file.
                 std::vector<std::string>::iterator it;
-                vector<std::string> vec = utils.getFileContent(file_path_s);
+                vector<std::string> vec = Utils::getFileContent(file_path_s);
                 it = vec.begin();
                 for (it = vec.begin(); it < vec.end(); it++) {
                     std::string item = *it;
                     if (item.length() > 0 && !(item.rfind("#", 0) == 0)) {
-                        std::vector<std::string> vec2 = utils.split(item, '=');
+                        std::vector<std::string> vec2 = Utils::split(item, '=');
                         if (vec2.at(0).compare("kafka.host") == 0) {
                             if (item.substr(item.length() - 1, item.length()).compare("=") != 0) {
                                 std::string kafka_server_IP = vec2.at(1);
@@ -733,7 +726,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             Partitioner graphPartitioner(numberOfPartitions, 1, spt::Algorithms::HASH);
 
             string topic_name_s(topic_name);
-            topic_name_s = utils.trim_copy(topic_name_s, " \f\n\r\t\v");
+            topic_name_s = Utils::trim_copy(topic_name_s, " \f\n\r\t\v");
             stream_topic_name = topic_name_s;
             kstream->Subscribe(topic_name_s);
             frontend_logger.log("Start listening to " + topic_name_s, "info");
@@ -782,8 +775,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string graphID(graph_id);
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
 
             if (JasmineGraphFrontEnd::graphExistsByID(graphID, sqlite)) {
@@ -840,8 +832,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string gData(graph_data);
 
-            Utils utils;
-            gData = utils.trim_copy(gData, " \f\n\r\t\v");
+            gData = Utils::trim_copy(gData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + gData, "info");
 
             if (gData.length() == 0) {
@@ -850,7 +841,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             }
             string path = gData;
 
-            if (utils.fileExists(path)) {
+            if (Utils::fileExists(path)) {
                 frontend_logger.log("Path exists", "info");
 
                 JSONParser *jsonParser = new JSONParser();
@@ -915,8 +906,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
                 string priority(priority_data);
 
-                Utils utils;
-                priority = utils.trim_copy(priority, " \f\n\r\t\v");
+                priority = Utils::trim_copy(priority, " \f\n\r\t\v");
 
                 if (!(std::find_if(priority.begin(), priority.end(),
                                    [](unsigned char c) { return !std::isdigit(c); }) == priority.end())) {
@@ -1111,8 +1101,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 }
             }
         } else if (line.compare(MERGE) == 0) {
-            Utils utils;
-            std::string federatedEnabled = utils.getJasmineGraphProperty("org.jasminegraph.federated.enabled");
+            std::string federatedEnabled = Utils::getJasmineGraphProperty("org.jasminegraph.federated.enabled");
             string message = "Available main flags:\r\n";
             write(connFd, message.c_str(), message.size());
             string flags = Conts::FLAGS::GRAPH_ID;
@@ -1126,7 +1115,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             read(connFd, train_data, 300);
 
             string trainData(train_data);
-            trainData = utils.trim_copy(trainData, " \f\n\r\t\v");
+            trainData = Utils::trim_copy(trainData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + trainData, "info");
 
             std::vector<std::string> trainargs = Utils::split(trainData, ' ');
@@ -1171,7 +1160,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
             read(connFd, train_data, 300);
 
             string trainData(train_data);
-            trainData = utils.trim_copy(trainData, " \f\n\r\t\v");
+            trainData = Utils::trim_copy(trainData, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + trainData, "info");
 
             std::vector<std::string> trainargs = Utils::split(trainData, ' ');
@@ -1206,12 +1195,11 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
 
-            Utils utils;
-            std::string federatedEnabled = utils.getJasmineGraphProperty("org.jasminegraph.federated.enabled");
+            std::string federatedEnabled = Utils::getJasmineGraphProperty("org.jasminegraph.federated.enabled");
 
             if (federatedEnabled == "true") {
                 JasmineGraphServer *jasmineServer = new JasmineGraphServer();
-                if (utils.getJasmineGraphProperty("org.jasminegraph.fl.org.training") == "true") {
+                if (Utils::getJasmineGraphProperty("org.jasminegraph.fl.org.training") == "true") {
                     frontend_logger.log("Initiate org communication", "info");
                     jasmineServer->initiateOrgCommunication(graphID, trainData, sqlite);
 
@@ -1250,8 +1238,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string graphID(graph_id);
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
 
             JasmineGraphServer *jasmineServer = new JasmineGraphServer();
@@ -1292,8 +1279,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string graphID(graph_id);
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
 
             JasmineGraphServer *jasmineServer = new JasmineGraphServer();
@@ -1357,8 +1343,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 }
             }
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
             frontend_logger.log("Alpha value: " + to_string(alpha), "info");
             frontend_logger.log("Iterations value: " + to_string(iterations), "info");
@@ -1401,8 +1386,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string graphID(graph_id);
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
 
             JasmineGraphServer *jasmineServer = new JasmineGraphServer();
@@ -1443,8 +1427,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string graphID(graph_id);
 
-            Utils utils;
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             frontend_logger.log("Graph ID received: " + graphID, "info");
 
             JasmineGraphServer *jasmineServer = new JasmineGraphServer();
@@ -1463,7 +1446,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 continue;
             }
         } else if (line.compare(PREDICT) == 0) {
-            if (utils.getJasmineGraphProperty("org.jasminegraph.federated.enabled") == "true") {
+            if (Utils::getJasmineGraphProperty("org.jasminegraph.federated.enabled") == "true") {
                 // check if the model is available
                 // then pass the information to the jasminegraph worker
 
@@ -1486,8 +1469,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 read(connFd, predict_data, 300);
                 string predictData(predict_data);
 
-                Utils utils;
-                predictData = utils.trim_copy(predictData, " \f\n\r\t\v");
+                predictData = Utils::trim_copy(predictData, " \f\n\r\t\v");
                 frontend_logger.log("Data received: " + predictData, "info");
 
                 std::vector<std::string> strArr = Utils::split(predictData, '|');
@@ -1518,8 +1500,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 read(connFd, predict_data, 300);
                 string predictData(predict_data);
 
-                Utils utils;
-                predictData = utils.trim_copy(predictData, " \f\n\r\t\v");
+                predictData = Utils::trim_copy(predictData, " \f\n\r\t\v");
                 frontend_logger.log("Data received: " + predictData, "info");
 
                 std::vector<std::string> strArr = Utils::split(predictData, '|');
@@ -1533,7 +1514,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
                 path = strArr[1];
 
                 if (JasmineGraphFrontEnd::isGraphActiveAndTrained(graphID, sqlite)) {
-                    if (utils.fileExists(path)) {
+                    if (Utils::fileExists(path)) {
                         std::cout << "Path exists" << endl;
                         JasminGraphLinkPredictor *jasminGraphLinkPredictor = new JasminGraphLinkPredictor();
                         jasminGraphLinkPredictor->initiateLinkPrediction(graphID, path, masterIP);
@@ -1560,8 +1541,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string remote_worker_data(worker_data);
 
-            Utils utils;
-            remote_worker_data = utils.trim_copy(remote_worker_data, " \f\n\r\t\v");
+            remote_worker_data = Utils::trim_copy(remote_worker_data, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + remote_worker_data, "info");
             string host = "";
             string port = "";
@@ -1604,8 +1584,7 @@ void *frontendservicesesion(std::string masterIP, int connFd, SQLiteDBInterface 
 
             string command_info(category);
 
-            Utils utils;
-            command_info = utils.trim_copy(command_info, " \f\n\r\t\v");
+            command_info = Utils::trim_copy(command_info, " \f\n\r\t\v");
             frontend_logger.log("Data received: " + command_info, "info");
 
             std::vector<vector<pair<string, string>>> categoryResults =
@@ -2010,7 +1989,6 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
     int port;
     int dataPort;
     std::string workerList;
-    Utils utils;
 
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator workerIter;
     for (workerIter = graphPartitionedHosts.begin(); workerIter != graphPartitionedHosts.end(); workerIter++) {
@@ -2021,7 +1999,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         dataPort = workerPartition.dataPort;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         workerList.append(host + ":" + std::to_string(port) + ":" + partition + ",");
@@ -2038,7 +2016,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         dataPort = workerPartition.dataPort;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         int sockfd;
@@ -2078,7 +2056,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         string response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2096,7 +2074,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2117,7 +2095,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2135,7 +2113,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2154,7 +2132,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2172,7 +2150,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2190,7 +2168,7 @@ void JasmineGraphServer::pageRank(std::string graphID, double alpha, int iterati
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2209,7 +2187,6 @@ void JasmineGraphServer::egoNet(std::string graphID) {
     int port;
     int dataPort;
     std::string workerList;
-    Utils utils;
 
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator workerit;
     for (workerit = graphPartitionedHosts.begin(); workerit != graphPartitionedHosts.end(); workerit++) {
@@ -2220,7 +2197,7 @@ void JasmineGraphServer::egoNet(std::string graphID) {
         dataPort = workerPartition.dataPort;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         workerList.append(host + ":" + std::to_string(port) + ":" + partition + ",");
@@ -2265,7 +2242,7 @@ void JasmineGraphServer::egoNet(std::string graphID) {
     bzero(data, 301);
     read(sockfd, data, 300);
     string response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
         frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2283,7 +2260,7 @@ void JasmineGraphServer::egoNet(std::string graphID) {
     bzero(data, 301);
     read(sockfd, data, 300);
     response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
         frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2304,7 +2281,7 @@ void JasmineGraphServer::egoNet(std::string graphID) {
     bzero(data, 301);
     read(sockfd, data, 300);
     response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
         frontend_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");

--- a/src/frontend/core/executor/impl/TriangleCountExecutor.cpp
+++ b/src/frontend/core/executor/impl/TriangleCountExecutor.cpp
@@ -35,7 +35,6 @@ TriangleCountExecutor::TriangleCountExecutor(SQLiteDBInterface db, PerformanceSQ
 }
 
 void TriangleCountExecutor::execute() {
-    Utils utils;
     int uniqueId = getUid();
     std::string masterIP = request.getMasterIP();
     std::string graphId = request.getParameter(Conts::PARAM_KEYS::GRAPH_ID);
@@ -43,11 +42,11 @@ void TriangleCountExecutor::execute() {
     std::string queueTime = request.getParameter(Conts::PARAM_KEYS::QUEUE_TIME);
     std::string graphSLAString = request.getParameter(Conts::PARAM_KEYS::GRAPH_SLA);
 
-    bool canCalibrate = utils.parseBoolean(canCalibrateString);
+    bool canCalibrate = Utils::parseBoolean(canCalibrateString);
     int threadPriority = request.getPriority();
 
     std::string autoCalibrateString = request.getParameter(Conts::PARAM_KEYS::AUTO_CALIBRATION);
-    bool autoCalibrate = utils.parseBoolean(autoCalibrateString);
+    bool autoCalibrate = Utils::parseBoolean(autoCalibrateString);
 
     if (threadPriority == Conts::HIGH_PRIORITY_DEFAULT_VALUE) {
         highPriorityGraphList.push_back(graphId);
@@ -83,7 +82,7 @@ void TriangleCountExecutor::execute() {
     long result = 0;
     bool isCompositeAggregation = false;
     Utils::worker aggregatorWorker;
-    vector<Utils::worker> workerList = utils.getWorkerList(sqlite);
+    vector<Utils::worker> workerList = Utils::getWorkerList(sqlite);
     int workerListSize = workerList.size();
     int partitionCount = 0;
     std::vector<std::future<long>> intermRes;
@@ -109,8 +108,8 @@ void TriangleCountExecutor::execute() {
 
     if (isCompositeAggregation) {
         std::string aggregatorFilePath =
-            utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
-        std::vector<std::string> graphFiles = utils.getListOfFilesInDirectory(aggregatorFilePath);
+            Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+        std::vector<std::string> graphFiles = Utils::getListOfFilesInDirectory(aggregatorFilePath);
 
         std::vector<std::string>::iterator graphFilesIterator;
         std::string compositeFileNameFormat = graphId + "_compositecentralstore_";
@@ -311,7 +310,6 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     long triangleCount;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -322,7 +320,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     triangleCount_logger.log("###TRIANGLE-COUNT-EXECUTOR### Get Host By Name : " + host, "info");
@@ -353,7 +351,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -384,7 +382,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -399,7 +397,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -415,7 +413,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -432,7 +430,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
             read(sockfd, data, 300);
             response = (data);
             triangleCount_logger.log("Got response : |" + response + "|", "info");
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             triangleCount = atol(response.c_str());
         }
 
@@ -460,7 +458,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
                     size_t lastIndex = fileName.find_last_of(".");
                     string rawFileName = fileName.substr(0, lastIndex);
 
-                    std::vector<std::string> fileNameParts = utils.split(rawFileName, '_');
+                    std::vector<std::string> fileNameParts = Utils::split(rawFileName, '_');
 
                     /*Partition numbers are extracted from  the file name. The starting index of partition number is 2.
                      * Therefore the loop starts with 2*/
@@ -487,7 +485,7 @@ long TriangleCountExecutor::getTriangleCount(int graphId, std::string host, int 
                     size_t lastindex = fileName.find_last_of(".");
                     string rawFileName = fileName.substr(0, lastindex);
 
-                    std::vector<std::string> fileNameParts = utils.split(rawFileName, '_');
+                    std::vector<std::string> fileNameParts = Utils::split(rawFileName, '_');
 
                     for (int index = 2; index < fileNameParts.size(); ++index) {
                         if (fileNameParts[index] == std::to_string(partitionId)) {
@@ -797,7 +795,6 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     string isFileAccessible = "false";
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -808,7 +805,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
     }
 
     if (aggregatorHostName.find('@') != std::string::npos) {
-        aggregatorHostName = utils.split(aggregatorHostName, '@')[1];
+        aggregatorHostName = Utils::split(aggregatorHostName, '@')[1];
     }
 
     server = gethostbyname(aggregatorHostName.c_str());
@@ -838,7 +835,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -868,7 +865,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_TYPE) == 0) {
             result_wr = write(sockfd, fileType.c_str(), fileType.size());
@@ -880,7 +877,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (fileType.compare(JasmineGraphInstanceProtocol::FILE_TYPE_CENTRALSTORE_AGGREGATE) == 0) {
                 if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -893,7 +890,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
                     bzero(data, 301);
                     read(sockfd, data, 300);
                     response = (data);
-                    response = utils.trim_copy(response, " \f\n\r\t\v");
+                    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                         result_wr = write(sockfd, partitionId.c_str(), partitionId.size());
@@ -905,7 +902,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
                         bzero(data, 301);
                         read(sockfd, data, 300);
                         response = (data);
-                        isFileAccessible = utils.trim_copy(response, " \f\n\r\t\v");
+                        isFileAccessible = Utils::trim_copy(response, " \f\n\r\t\v");
                     }
                 }
             } else if (fileType.compare(JasmineGraphInstanceProtocol::FILE_TYPE_CENTRALSTORE_COMPOSITE) == 0) {
@@ -921,7 +918,7 @@ string TriangleCountExecutor::isFileAccessibleToWorker(std::string graphId, std:
                     bzero(data, 301);
                     read(sockfd, data, 300);
                     response = (data);
-                    isFileAccessible = utils.trim_copy(response, " \f\n\r\t\v");
+                    isFileAccessible = Utils::trim_copy(response, " \f\n\r\t\v");
                 }
             }
         }
@@ -940,12 +937,11 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
     std::string aggregateStoreFile = aggregatorFilePath + "/" + fileName;
     JasmineGraphServer *jasmineServer = new JasmineGraphServer();
 
-    int fileSize = utils.getFileSize(aggregateStoreFile);
+    int fileSize = Utils::getFileSize(aggregateStoreFile);
     std::string fileLength = to_string(fileSize);
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -956,7 +952,7 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
     }
 
     if (aggregatorHostName.find('@') != std::string::npos) {
-        aggregatorHostName = utils.split(aggregatorHostName, '@')[1];
+        aggregatorHostName = Utils::split(aggregatorHostName, '@')[1];
     }
 
     server = gethostbyname(aggregatorHostName.c_str());
@@ -986,7 +982,7 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1018,7 +1014,7 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
             triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1033,7 +1029,7 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                 triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1048,7 +1044,7 @@ std::string TriangleCountExecutor::copyCompositeCentralStoreToAggregator(std::st
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                     triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1130,7 +1126,6 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -1166,7 +1161,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1199,7 +1194,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1214,7 +1209,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1248,7 +1243,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1264,7 +1259,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             string status = response.substr(response.size() - 5);
             std::string result = response.substr(0, response.size() - 5);
 
@@ -1277,7 +1272,7 @@ string TriangleCountExecutor::countCompositeCentralStoreTriangles(std::string ag
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 status = response.substr(response.size() - 5);
                 std::string triangleResponse = response.substr(0, response.size() - 5);
                 result = result + triangleResponse;
@@ -1331,13 +1326,12 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
     std::string fileName = std::to_string(graphId) + "_centralstore_" + std::to_string(partitionId) + ".gz";
     std::string centralStoreFile = aggregatorFilePath + "/" + fileName;
     JasmineGraphServer *jasmineServer = new JasmineGraphServer();
 
-    int fileSize = utils.getFileSize(centralStoreFile);
+    int fileSize = Utils::getFileSize(centralStoreFile);
     std::string fileLength = to_string(fileSize);
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -1348,7 +1342,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
     }
 
     if (aggregatorHostName.find('@') != std::string::npos) {
-        aggregatorHostName = utils.split(aggregatorHostName, '@')[1];
+        aggregatorHostName = Utils::split(aggregatorHostName, '@')[1];
     }
 
     server = gethostbyname(aggregatorHostName.c_str());
@@ -1378,7 +1372,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1409,7 +1403,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
             triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1424,7 +1418,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                 triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1439,7 +1433,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                     triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1465,7 +1459,7 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            // response = utils.trim_copy(response, " \f\n\r\t\v");
+            // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                 triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1521,7 +1515,6 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -1531,7 +1524,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1561,7 +1554,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1592,7 +1585,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1607,7 +1600,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1623,7 +1616,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1639,7 +1632,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
         }
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1655,7 +1648,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             string status = response.substr(response.size() - 5);
             std::string result = response.substr(0, response.size() - 5);
 
@@ -1668,7 +1661,7 @@ string TriangleCountExecutor::countCentralStoreTriangles(std::string aggregatorH
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 status = response.substr(response.size() - 5);
                 std::string triangleResponse = response.substr(0, response.size() - 5);
                 result = result + triangleResponse;
@@ -1696,7 +1689,6 @@ int TriangleCountExecutor::collectPerformaceData(PerformanceSQLiteDBInterface pe
     time_t end;
     PerformanceUtil performanceUtil;
     performanceUtil.init();
-    Utils utils;
 
     std::vector<Place> placeList = performanceUtil.getHostReporterList();
     std::string slaCategoryId = performanceUtil.getSLACategoryId(command, category);

--- a/src/frontend/core/executor/impl/TriangleCountExecutor.cpp
+++ b/src/frontend/core/executor/impl/TriangleCountExecutor.cpp
@@ -1459,7 +1459,6 @@ std::string TriangleCountExecutor::copyCentralStoreToAggregator(std::string aggr
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                 triangleCount_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");

--- a/src/metadb/SQLiteDBInterface.cpp
+++ b/src/metadb/SQLiteDBInterface.cpp
@@ -22,8 +22,7 @@ using namespace std;
 Logger db_logger;
 
 int SQLiteDBInterface::init() {
-    Utils utils;
-    int rc = sqlite3_open(utils.getJasmineGraphProperty("org.jasminegraph.db.location").c_str(), &database);
+    int rc = sqlite3_open(Utils::getJasmineGraphProperty("org.jasminegraph.db.location").c_str(), &database);
     if (rc) {
         db_logger.log("Cannot open database: " + string(sqlite3_errmsg(database)), "error");
         return (-1);

--- a/src/ml/trainer/JasminGraphTrainingInitiator.cpp
+++ b/src/ml/trainer/JasminGraphTrainingInitiator.cpp
@@ -44,9 +44,8 @@ void JasminGraphTrainingInitiator::initiateTrainingLocally(std::string graphID, 
     cout << partition_count << endl;
     std::thread *workerThreads = new std::thread[partition_count];
 
-    Utils utils;
-    string prefix = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder");
-    string attr_prefix = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    string prefix = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder");
+    string attr_prefix = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     string trainarg_prefix = "Graphsage Unsupervised_train ";
     trainingArgs = trainarg_prefix + trainingArgs + " --train_prefix " + prefix + "/" + graphID +
                    " --train_attr_prefix " + attr_prefix + "/" + graphID;
@@ -80,7 +79,6 @@ void JasminGraphTrainingInitiator::initiateTrainingLocally(std::string graphID, 
 
 bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int dataPort, std::string trainingArgs,
                                                  int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     std::cout << pthread_self() << " host : " << host << " port : " << port << " DPort : " << dataPort << std::endl;
     int sockfd;
@@ -98,7 +96,7 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -128,11 +126,11 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
     read(sockfd, data, DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         trainer_log.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         int result_wr = write(sockfd, server_host.c_str(), server_host.size());
         if (result_wr < 0) {
             trainer_log.log("Error writing to socket", "error");
@@ -145,7 +143,7 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
         read(sockfd, data, DATA_LENGTH);
         string response = (data);
 
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             trainer_log.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -164,7 +162,7 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
         bzero(data, DATA_LENGTH + 1);
         read(sockfd, data, DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         std::cout << response << std::endl;
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             trainer_log.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -178,7 +176,7 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
             bzero(data, DATA_LENGTH + 1);
             read(sockfd, data, DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             if (response.compare(JasmineGraphInstanceProtocol::SEND_PARTITION_ITERATION) == 0) {
                 trainer_log.log("Received : " + JasmineGraphInstanceProtocol::SEND_PARTITION_ITERATION, "info");
                 result_wr = write(sockfd, to_string(iteration).c_str(), to_string(iteration).size());
@@ -192,7 +190,7 @@ bool JasminGraphTrainingInitiator::initiateTrain(std::string host, int port, int
                 bzero(data, DATA_LENGTH + 1);
                 read(sockfd, data, DATA_LENGTH);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_PARTITION_COUNT) == 0) {
                     trainer_log.log("Received : " + JasmineGraphInstanceProtocol::SEND_PARTITION_COUNT, "info");
                     result_wr = write(sockfd, partCount.c_str(), partCount.size());

--- a/src/partitioner/local/JSONParser.cpp
+++ b/src/partitioner/local/JSONParser.cpp
@@ -39,7 +39,7 @@ JSONParser::JSONParser() {}
 
 void JSONParser::jsonParse(string filePath) {
     this->inputFilePath = filePath;
-    this->outputFilePath = utils.getHomeDir() + "/.jasminegraph/tmp/JSONParser/output";
+    this->outputFilePath = Utils::getHomeDir() + "/.jasminegraph/tmp/JSONParser/output";
     const clock_t begin = clock();
     readFile();
     float time = float(clock() - begin) / CLOCKS_PER_SEC;
@@ -95,10 +95,10 @@ void JSONParser::attributeFileCreate() {
 }
 
 void JSONParser::readFile() {
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/JSONParser");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/JSONParser/output");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/JSONParser");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/JSONParser/output");
 
     std::thread *workerThreads = new std::thread[2];
     workerThreads[0] = std::thread(&JSONParser::createEdgeList, this);

--- a/src/partitioner/local/JSONParser.h
+++ b/src/partitioner/local/JSONParser.h
@@ -49,7 +49,6 @@ class JSONParser {
 
     string inputFilePath;
     string outputFilePath;
-    Utils utils;
 };
 
 #endif  // JASMINEGRAPH_JSONPARSER_H

--- a/src/partitioner/local/MetisPartitioner.cpp
+++ b/src/partitioner/local/MetisPartitioner.cpp
@@ -27,8 +27,7 @@ std::mutex dbLock;
 
 MetisPartitioner::MetisPartitioner(SQLiteDBInterface *sqlite) {
     this->sqlite = *sqlite;
-    Utils utils;
-    std::string partitionCount = utils.getJasmineGraphProperty("org.jasminegraph.server.npartitions");
+    std::string partitionCount = Utils::getJasmineGraphProperty("org.jasminegraph.server.npartitions");
     nParts = atoi(partitionCount.c_str());
 }
 
@@ -36,13 +35,13 @@ void MetisPartitioner::loadDataSet(string inputFilePath, int graphID) {
     partitioner_logger.log("Processing dataset for partitioning", "info");
     this->graphID = graphID;
     // Output directory is created under the users home directory '~/.jasminegraph/tmp/'
-    this->outputFilePath = utils.getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID);
+    this->outputFilePath = Utils::getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID);
 
     // Have to call createDirectory twice since it does not support recursive directory creation. Could use
     // boost::filesystem for path creation
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp");
-    this->utils.createDirectory(this->outputFilePath);
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp");
+    Utils::createDirectory(this->outputFilePath);
 
     std::ifstream dbFile;
     dbFile.open(inputFilePath, std::ios::binary | std::ios::in);
@@ -214,7 +213,7 @@ std::vector<std::map<int, std::string>> MetisPartitioner::partitioneWithGPMetis(
     char buffer[128];
     std::string result = "";
     FILE *headerModify;
-    std::string metisBinDir = utils.getJasmineGraphProperty("org.jasminegraph.partitioner.metis.bin");
+    std::string metisBinDir = Utils::getJasmineGraphProperty("org.jasminegraph.partitioner.metis.bin");
     string metisCommand =
         metisBinDir + "/gpmetis " + this->outputFilePath + "/grf " + to_string(this->nParts) + " 2>&1";
     partitioner_logger.log("metisCommand " + metisCommand, "info");
@@ -662,7 +661,7 @@ void MetisPartitioner::writeSerializedPartitionFiles(int part) {
     hashMapLocalStore->storePartEdgeMap(partEdgeMap, outputFilePart);
 
     // Compress part files
-    this->utils.compressFile(outputFilePart);
+    Utils::compressFile(outputFilePart);
     partFileMutex.lock();
     partitionFileList.insert(make_pair(part, outputFilePart + ".gz"));
     partFileMutex.unlock();
@@ -678,7 +677,7 @@ void MetisPartitioner::writeSerializedMasterFiles(int part) {
     JasmineGraphHashMapCentralStore *hashMapCentralStore = new JasmineGraphHashMapCentralStore();
     hashMapCentralStore->storePartEdgeMap(partMasterEdgeMap, outputFilePartMaster);
 
-    this->utils.compressFile(outputFilePartMaster);
+    Utils::compressFile(outputFilePartMaster);
     masterFileMutex.lock();
     centralStoreFileList.insert(make_pair(part, outputFilePartMaster + ".gz"));
     masterFileMutex.unlock();
@@ -694,7 +693,7 @@ void MetisPartitioner::writeSerializedDuplicateMasterFiles(int part) {
     JasmineGraphHashMapCentralStore *hashMapCentralStore = new JasmineGraphHashMapCentralStore();
     hashMapCentralStore->storePartEdgeMap(partMasterEdgeMap, outputFilePartMaster);
 
-    this->utils.compressFile(outputFilePartMaster);
+    Utils::compressFile(outputFilePartMaster);
     masterFileMutex.lock();
     centralStoreDuplicateFileList.insert(make_pair(part, outputFilePartMaster + ".gz"));
     masterFileMutex.unlock();
@@ -738,7 +737,7 @@ void MetisPartitioner::writePartitionFiles(int part) {
     }
 
     // Compress part files
-    this->utils.compressFile(outputFilePart);
+    Utils::compressFile(outputFilePart);
     partFileMutex.lock();
     partitionFileList.insert(make_pair(part, outputFilePart + ".gz"));
     partFileMutex.unlock();
@@ -782,7 +781,7 @@ void MetisPartitioner::writeMasterFiles(int part) {
         masterFile.close();
     }
 
-    this->utils.compressFile(outputFilePartMaster);
+    Utils::compressFile(outputFilePartMaster);
     masterFileMutex.lock();
     centralStoreFileList.insert(make_pair(part, outputFilePartMaster + ".gz"));
     masterFileMutex.unlock();
@@ -817,7 +816,7 @@ void MetisPartitioner::writeTextAttributeFilesForPartitions(int part) {
 
     partfile.close();
 
-    this->utils.compressFile(attributeFilePart);
+    Utils::compressFile(attributeFilePart);
     partAttrFileMutex.lock();
     partitionAttributeFileList.insert(make_pair(part, attributeFilePart + ".gz"));
     partAttrFileMutex.unlock();
@@ -852,7 +851,7 @@ void MetisPartitioner::writeTextAttributeFilesForMasterParts(int part) {
 
     partfile.close();
 
-    this->utils.compressFile(attributeFilePartMaster);
+    Utils::compressFile(attributeFilePartMaster);
     masterAttrFileMutex.lock();
     centralStoreAttributeFileList.insert(make_pair(part, attributeFilePartMaster + ".gz"));
     masterAttrFileMutex.unlock();
@@ -886,7 +885,7 @@ void MetisPartitioner::writeRDFAttributeFilesForPartitions(int part) {
     JasmineGraphHashMapLocalStore *hashMapLocalStore = new JasmineGraphHashMapLocalStore();
     hashMapLocalStore->storeAttributes(partitionedEdgeAttributes, attributeFilePart);
 
-    this->utils.compressFile(attributeFilePart);
+    Utils::compressFile(attributeFilePart);
     partAttrFileMutex.lock();
     partitionAttributeFileList.insert(make_pair(part, attributeFilePart + ".gz"));
     partAttrFileMutex.unlock();
@@ -919,7 +918,7 @@ void MetisPartitioner::writeRDFAttributeFilesForMasterParts(int part) {
     JasmineGraphHashMapLocalStore *hashMapLocalStore = new JasmineGraphHashMapLocalStore();
     hashMapLocalStore->storeAttributes(centralStoreEdgeAttributes, attributeFilePartMaster);
 
-    this->utils.compressFile(attributeFilePartMaster);
+    Utils::compressFile(attributeFilePartMaster);
     masterAttrFileMutex.lock();
     centralStoreAttributeFileList.insert(make_pair(part, attributeFilePartMaster + ".gz"));
     masterAttrFileMutex.unlock();
@@ -931,7 +930,7 @@ string MetisPartitioner::reformatDataSet(string inputFilePath, int graphID) {
     std::ifstream inFile;
     inFile.open(inputFilePath, std::ios::binary | std::ios::in);
 
-    string outputFile = utils.getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID) + "/" +
+    string outputFile = Utils::getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID) + "/" +
                         std::to_string(this->graphID);
     std::ofstream outFile;
     outFile.open(outputFile);
@@ -1093,10 +1092,10 @@ void MetisPartitioner::writeSerializedCompositeMasterFiles(std::string part) {
     JasmineGraphHashMapCentralStore *hashMapCentralStore = new JasmineGraphHashMapCentralStore();
     hashMapCentralStore->storePartEdgeMap(partMasterEdgeMap, outputFilePartMaster);
 
-    std::vector<std::string> graphIds = this->utils.split(part, '_');
+    std::vector<std::string> graphIds = Utils::split(part, '_');
     std::vector<std::string>::iterator graphIdIterator;
 
-    this->utils.compressFile(outputFilePartMaster);
+    Utils::compressFile(outputFilePartMaster);
     masterFileMutex.lock();
     for (graphIdIterator = graphIds.begin(); graphIdIterator != graphIds.end(); ++graphIdIterator) {
         std::string graphId = *graphIdIterator;

--- a/src/partitioner/local/MetisPartitioner.h
+++ b/src/partitioner/local/MetisPartitioner.h
@@ -66,7 +66,6 @@ class MetisPartitioner {
     bool zeroflag = false;
     SQLiteDBInterface sqlite;
     int graphID;
-    Utils utils;
     string graphType;
     int smallestVertex = std::numeric_limits<int>::max();
     string graphAttributeType;

--- a/src/partitioner/local/RDFParser.cpp
+++ b/src/partitioner/local/RDFParser.cpp
@@ -299,10 +299,10 @@ void GetConfig::readConfigFile(string &configFile, int graphId) {
 
 void GetConfig::writeEdgesToFile() {
     ofstream file;
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/");
-    this->utils.createDirectory(utils.getHomeDir() + "/.jasminegraph/tmp/" + to_string(this->graphID));
-    file.open(utils.getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID) + "/" +
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/");
+    Utils::createDirectory(Utils::getHomeDir() + "/.jasminegraph/tmp/" + to_string(this->graphID));
+    file.open(Utils::getHomeDir() + "/.jasminegraph/tmp/" + std::to_string(this->graphID) + "/" +
               std::to_string(this->graphID));
     for (int i = 0; i < edgelist.size(); i++) {
         file << edgelist[i].first << " " << edgelist[i].second << endl;

--- a/src/partitioner/local/RDFParser.h
+++ b/src/partitioner/local/RDFParser.h
@@ -69,7 +69,6 @@ class GetConfig {
     static std::map<long, string[7]> getAttributesMap();
 
  private:
-    Utils utils;
     int graphID;
     xercesc::XercesDOMParser *m_ConfigFileParser;
     char *m_OptionA;

--- a/src/partitioner/local/RDFPartitioner.h
+++ b/src/partitioner/local/RDFPartitioner.h
@@ -73,8 +73,6 @@ class RDFPartitioner {
 
     string inputFilePath;
 
-    Utils utils;
-
     std::map<string, long> nodes;
     std::map<long, string> nodesTemp;
     std::map<string, long> predicates;

--- a/src/performance/metrics/PerformanceUtil.cpp
+++ b/src/performance/metrics/PerformanceUtil.cpp
@@ -13,7 +13,6 @@ limitations under the License.
 
 #include "PerformanceUtil.h"
 
-Utils systemUtils;
 using namespace std::chrono;
 std::map<std::string, std::vector<ResourceUsageInfo>> resourceUsageMap;
 
@@ -27,7 +26,7 @@ void PerformanceUtil::init() {
 }
 
 int PerformanceUtil::collectPerformanceStatistics() {
-    vector<std::string> hostList = systemUtils.getHostListFromProperties();
+    vector<std::string> hostList = Utils::getHostListFromProperties();
     int hostListSize = hostList.size();
     int counter = 0;
     std::vector<std::future<long>> intermRes;
@@ -206,7 +205,6 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -235,11 +233,11 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         scheduler_logger.log("Sent : " + server_host, "info");
 
@@ -249,7 +247,7 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -260,7 +258,7 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                 write(sockfd, isResourceAllocationRequired.c_str(), isResourceAllocationRequired.size());
@@ -269,7 +267,7 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 scheduler_logger.log("Performance Response " + response, "info");
 
@@ -313,7 +311,6 @@ void PerformanceUtil::collectRemotePerformanceData(std::string host, int port, s
 void PerformanceUtil::collectLocalPerformanceData(std::string isVMStatManager, std::string isResourceAllocationRequired,
                                                   std::string hostId, std::string placeId) {
     StatisticCollector statisticCollector;
-    Utils utils;
     statisticCollector.init();
 
     int memoryUsage = statisticCollector.getMemoryUsageByProcess();
@@ -322,7 +319,7 @@ void PerformanceUtil::collectLocalPerformanceData(std::string isVMStatManager, s
     auto executedTime = std::chrono::system_clock::now();
     std::time_t reportTime = std::chrono::system_clock::to_time_t(executedTime);
     std::string reportTimeString(std::ctime(&reportTime));
-    reportTimeString = utils.trim_copy(reportTimeString, " \f\n\r\t\v");
+    reportTimeString = Utils::trim_copy(reportTimeString, " \f\n\r\t\v");
 
     if (isVMStatManager.find("true") != std::string::npos) {
         std::string vmLevelStatistics =
@@ -364,7 +361,6 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     std::string graphSlaId;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -375,7 +371,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -398,7 +394,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -408,7 +404,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
@@ -418,7 +414,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             scheduler_logger.log("Received : " + response, "info");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -428,7 +424,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                     write(sockfd, isResourceAllocationRequired.c_str(), isResourceAllocationRequired.size());
@@ -438,7 +434,7 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
                     bzero(data, 301);
                     read(sockfd, data, 300);
                     response = (data);
-                    response = utils.trim_copy(response, " \f\n\r\t\v");
+                    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     scheduler_logger.log("Performance Response " + response, "info");
 
@@ -472,7 +468,6 @@ int PerformanceUtil::collectRemoteSLAResourceUtilization(std::string host, int p
 void PerformanceUtil::collectLocalSLAResourceUtilization(std::string graphId, std::string placeId, std::string command,
                                                          std::string category, int elapsedTime, bool autoCalibrate) {
     StatisticCollector statisticCollector;
-    Utils utils;
     statisticCollector.init();
     string graphSlaId;
 
@@ -481,7 +476,7 @@ void PerformanceUtil::collectLocalSLAResourceUtilization(std::string graphId, st
     auto executedTime = std::chrono::system_clock::now();
     std::time_t reportTime = std::chrono::system_clock::to_time_t(executedTime);
     std::string reportTimeString(std::ctime(&reportTime));
-    reportTimeString = utils.trim_copy(reportTimeString, " \f\n\r\t\v");
+    reportTimeString = Utils::trim_copy(reportTimeString, " \f\n\r\t\v");
 
     ResourceUsageInfo resourceUsageInfo;
     resourceUsageInfo.elapsedTime = std::to_string(elapsedTime);
@@ -506,7 +501,6 @@ ResourceConsumption PerformanceUtil::retrieveLocalResourceConsumption(std::strin
     ResourceConsumption placeResourceConsumption;
 
     StatisticCollector statisticCollector;
-    Utils utils;
     statisticCollector.init();
 
     int memoryUsage = statisticCollector.getMemoryUsageByProcess();
@@ -528,7 +522,6 @@ ResourceConsumption PerformanceUtil::retrieveRemoteResourceConsumption(std::stri
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     std::string graphSlaId;
     std::string isVMStatManager = "false";
     std::string isResourceAllocationRequired = "false";
@@ -560,11 +553,11 @@ ResourceConsumption PerformanceUtil::retrieveRemoteResourceConsumption(std::stri
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         scheduler_logger.log("Sent : " + server_host, "info");
 
@@ -574,7 +567,7 @@ ResourceConsumption PerformanceUtil::retrieveRemoteResourceConsumption(std::stri
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -584,7 +577,7 @@ ResourceConsumption PerformanceUtil::retrieveRemoteResourceConsumption(std::stri
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                 write(sockfd, isResourceAllocationRequired.c_str(), isResourceAllocationRequired.size());
@@ -593,7 +586,7 @@ ResourceConsumption PerformanceUtil::retrieveRemoteResourceConsumption(std::stri
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 scheduler_logger.log("Performance Response " + response, "info");
 
@@ -1046,7 +1039,6 @@ void PerformanceUtil::initiateCollectingRemoteSLAResourceUtilization(std::string
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     std::string graphSlaId;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -1057,7 +1049,7 @@ void PerformanceUtil::initiateCollectingRemoteSLAResourceUtilization(std::string
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1080,7 +1072,7 @@ void PerformanceUtil::initiateCollectingRemoteSLAResourceUtilization(std::string
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1090,7 +1082,7 @@ void PerformanceUtil::initiateCollectingRemoteSLAResourceUtilization(std::string
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
@@ -1100,7 +1092,7 @@ void PerformanceUtil::initiateCollectingRemoteSLAResourceUtilization(std::string
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             scheduler_logger.log("Received : " + response, "info");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -1119,7 +1111,6 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
     std::string graphSlaId;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -1130,7 +1121,7 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1153,7 +1144,7 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1163,7 +1154,7 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         scheduler_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
@@ -1173,7 +1164,7 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             string status = response.substr(response.size() - 5);
             std::string result = response.substr(0, response.size() - 5);
 
@@ -1183,7 +1174,7 @@ std::string PerformanceUtil::requestRemoteLoadAverages(std::string host, int por
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 status = response.substr(response.size() - 5);
                 std::string loadAverageString = response.substr(0, response.size() - 5);
                 result = result + loadAverageString;

--- a/src/performance/metrics/StatisticCollector.cpp
+++ b/src/performance/metrics/StatisticCollector.cpp
@@ -159,7 +159,6 @@ double StatisticCollector::getTotalCpuUsage() {
     std::string mpstatCommand = "mpstat";
     char buffer[BUFFER_SIZE];
     std::string result = "";
-    Utils utils;
     std::vector<std::string>::iterator paramNameIterator;
     int count = 0;
     double totalCPUUsage = 0;
@@ -174,14 +173,14 @@ double StatisticCollector::getTotalCpuUsage() {
             }
         }
         if (!result.empty()) {
-            std::vector<std::string> splittedStats = utils.split(result, '\n');
+            std::vector<std::string> splittedStats = Utils::split(result, '\n');
             int length = splittedStats.size();
             std::string parameterNames = splittedStats[length - 2];
             std::string parameterValues = splittedStats[length - 1];
-            std::vector<std::string> splittedParamNames = utils.split(parameterNames, ' ');
+            std::vector<std::string> splittedParamNames = Utils::split(parameterNames, ' ');
             splittedParamNames.erase(std::remove(splittedParamNames.begin(), splittedParamNames.end(), ""),
                                      splittedParamNames.end());
-            std::vector<std::string> splittedParamValues = utils.split(parameterValues, ' ');
+            std::vector<std::string> splittedParamValues = Utils::split(parameterValues, ' ');
             splittedParamValues.erase(std::remove(splittedParamValues.begin(), splittedParamValues.end(), ""),
                                       splittedParamValues.end());
 

--- a/src/performancedb/PerformanceSQLiteDBInterface.cpp
+++ b/src/performancedb/PerformanceSQLiteDBInterface.cpp
@@ -22,8 +22,7 @@ using namespace std;
 Logger perfdb_logger;
 
 int PerformanceSQLiteDBInterface::init() {
-    Utils utils;
-    int rc = sqlite3_open(utils.getJasmineGraphProperty("org.jasminegraph.performance.db.location").c_str(), &database);
+    int rc = sqlite3_open(Utils::getJasmineGraphProperty("org.jasminegraph.performance.db.location").c_str(), &database);
     if (rc) {
         perfdb_logger.log("Cannot open database: " + string(sqlite3_errmsg(database)), "error");
         return (-1);

--- a/src/performancedb/PerformanceSQLiteDBInterface.cpp
+++ b/src/performancedb/PerformanceSQLiteDBInterface.cpp
@@ -22,7 +22,8 @@ using namespace std;
 Logger perfdb_logger;
 
 int PerformanceSQLiteDBInterface::init() {
-    int rc = sqlite3_open(Utils::getJasmineGraphProperty("org.jasminegraph.performance.db.location").c_str(), &database);
+    int rc =
+        sqlite3_open(Utils::getJasmineGraphProperty("org.jasminegraph.performance.db.location").c_str(), &database);
     if (rc) {
         perfdb_logger.log("Cannot open database: " + string(sqlite3_errmsg(database)), "error");
         return (-1);

--- a/src/query/algorithms/linkprediction/JasminGraphLinkPredictor.cpp
+++ b/src/query/algorithms/linkprediction/JasminGraphLinkPredictor.cpp
@@ -84,7 +84,6 @@ void JasminGraphLinkPredictor::initiateLinkPrediction(std::string graphID, std::
 int JasminGraphLinkPredictor::sendQueryToWorker(std::string host, int port, int dataPort, int selectedHostPartitionsNo,
                                                 std::string graphID, std::string vertexCount, std::string filePath,
                                                 std::string hostsList, std::string masterIP) {
-    Utils utils;
     bool result = true;
     std::cout << pthread_self() << " host : " << host << " port : " << port << " DPort : " << dataPort << std::endl;
     int sockfd;
@@ -102,7 +101,7 @@ int JasminGraphLinkPredictor::sendQueryToWorker(std::string host, int port, int 
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -125,11 +124,11 @@ int JasminGraphLinkPredictor::sendQueryToWorker(std::string host, int port, int 
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         predictor_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         predictor_logger.log("Sent : " + server_host, "info");
 
@@ -139,7 +138,7 @@ int JasminGraphLinkPredictor::sendQueryToWorker(std::string host, int port, int 
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             predictor_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -153,14 +152,14 @@ int JasminGraphLinkPredictor::sendQueryToWorker(std::string host, int port, int 
             predictor_logger.log("Sent : No of partition in selected host " + to_string(selectedHostPartitionsNo),
                                  "info");
 
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             if (response.compare(JasmineGraphInstanceProtocol::SEND_HOSTS) == 0) {
                 predictor_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_HOSTS, "info");
                 /*Create a string with host details*/

--- a/src/server/JasmineGraphInstance.cpp
+++ b/src/server/JasmineGraphInstance.cpp
@@ -66,7 +66,6 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
     socklen_t len;
     struct sockaddr_in serv_addr;
     struct hostent *server;
-    Utils utils;
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -76,7 +75,7 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
     }
 
     if (masterHost.find('@') != std::string::npos) {
-        masterHost = utils.split(masterHost, '@')[1];
+        masterHost = Utils::split(masterHost, '@')[1];
     }
 
     graphInstance_logger.log("###INSTANCE### Get Host By Name : " + masterHost, "info");
@@ -107,7 +106,7 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
     read(sockfd, data, 300);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         graphInstance_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -122,7 +121,7 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
         bzero(data, 301);
         read(sockfd, data, 300);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             graphInstance_logger.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -138,7 +137,7 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
             bzero(data, 301);
             read(sockfd, data, 300);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::WORKER_INFO_SEND) == 0) {
                 std::string workerInfo = workerIP + "|" + workerPort;
@@ -169,11 +168,10 @@ bool JasmineGraphInstance::acknowledgeMaster(string masterHost, string workerIP,
 }
 
 void JasmineGraphInstance::startNmonAnalyzer(string enableNmon, int serverPort) {
-    Utils utils;
     if (enableNmon == "true") {
-        std::string nmonFileLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.nmon.file.location");
-        std::string numberOfSnapshots = utils.getJasmineGraphProperty("org.jasminegraph.server.nmon.snapshots");
-        std::string snapshotGap = utils.getJasmineGraphProperty("org.jasminegraph.server.nmon.snapshot.gap");
+        std::string nmonFileLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.nmon.file.location");
+        std::string numberOfSnapshots = Utils::getJasmineGraphProperty("org.jasminegraph.server.nmon.snapshots");
+        std::string snapshotGap = Utils::getJasmineGraphProperty("org.jasminegraph.server.nmon.snapshot.gap");
         std::string nmonFileName = nmonFileLocation + "nmon.log." + std::to_string(serverPort);
         std::string nmonStartupCommand =
             "nmon_x86_64_ubuntu18 -c " + numberOfSnapshots + " -s " + snapshotGap + " -T -F " + nmonFileName;
@@ -203,7 +201,6 @@ bool JasmineGraphInstance::isRunning() { return true; }
 
 bool JasmineGraphInstance::sendFileThroughService(std::string host, int dataPort, std::string fileName,
                                                   std::string filePath) {
-    Utils utils;
     int sockfd;
     char data[301];
     socklen_t len;
@@ -238,7 +235,7 @@ bool JasmineGraphInstance::sendFileThroughService(std::string host, int dataPort
     bzero(data, 301);
     read(sockfd, data, 300);
     string response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE) == 0) {
         std::cout << "Sending file " << filePath << " through port " << dataPort << std::endl;
 

--- a/src/server/JasmineGraphInstanceFileTransferService.cpp
+++ b/src/server/JasmineGraphInstanceFileTransferService.cpp
@@ -27,7 +27,6 @@ void *filetransferservicesession(void *dummyPt) {
     bzero(data, 301);
     read(connFd, data, 300);
     string fileName = (data);
-    // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
     string filePathWithName =
         Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 

--- a/src/server/JasmineGraphInstanceFileTransferService.cpp
+++ b/src/server/JasmineGraphInstanceFileTransferService.cpp
@@ -23,14 +23,13 @@ pthread_mutex_t thread_lock = PTHREAD_MUTEX_INITIALIZER;
 void *filetransferservicesession(void *dummyPt) {
     filetransferservicesessionargs *sessionargs = (filetransferservicesessionargs *)dummyPt;
     int connFd = sessionargs->connFd;
-    Utils utils;
     char data[301];
     bzero(data, 301);
     read(connFd, data, 300);
     string fileName = (data);
-    // fileName = utils.trim_copy(fileName, " \f\n\r\t\v");
+    // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
     string filePathWithName =
-        utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 
     write(connFd, JasmineGraphInstanceProtocol::SEND_FILE.c_str(), JasmineGraphInstanceProtocol::SEND_FILE.size());
     int bytesReceived = 0;

--- a/src/server/JasmineGraphInstanceService.cpp
+++ b/src/server/JasmineGraphInstanceService.cpp
@@ -171,7 +171,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             string partitionID = rawname.substr(rawname.find_last_of("_") + 1);
             pthread_mutex_lock(&file_lock);
@@ -267,7 +268,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
@@ -357,7 +359,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
@@ -445,7 +448,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
@@ -533,7 +537,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
@@ -1335,7 +1340,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
             std::string aggregatorFilePath =
                 Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
@@ -1438,7 +1444,8 @@ void *instanceservicesession(void *dummyPt) {
             Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath =
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
             std::string aggregatorFilePath =
                 Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
@@ -2053,7 +2060,8 @@ void *instanceservicesession(void *dummyPt) {
             predictargs.push_back(graphID);
             predictargs.push_back(vertexCount);
             predictargs.push_back(fullFilePath);
-            predictargs.push_back(Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
+            predictargs.push_back(
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
             predictargs.push_back(to_string(totalPartitions + stoi(ownPartitions)));
             std::vector<char *> predict_agrs_vector;
             std::transform(predictargs.begin(), predictargs.end(), std::back_inserter(predict_agrs_vector), converter);
@@ -2492,17 +2500,21 @@ int deleteGraphPartition(std::string graphID, std::string partitionID) {
     string centalStoreFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                                  graphID + +"_centralstore_" + partitionID;
     status |= Utils::deleteDirectory(centalStoreFilePath);
-    string centalStoreDuplicateFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
-                                          "/" + graphID + +"_centralstore_dp_" + partitionID;
+    string centalStoreDuplicateFilePath =
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID +
+        +"_centralstore_dp_" + partitionID;
     status |= Utils::deleteDirectory(centalStoreDuplicateFilePath);
     string attributeFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                                graphID + +"_attributes_" + partitionID;
     status |= Utils::deleteDirectory(attributeFilePath);
-    string attributeCentalStoreFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
-                                          "/" + graphID + +"_centralstore_attributes_" + partitionID;
+    string attributeCentalStoreFilePath =
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID +
+        +"_centralstore_attributes_" + partitionID;
     status |= Utils::deleteDirectory(attributeCentalStoreFilePath);
-    if (status == 0) instance_logger.info("Graph partition and centralstore files are now deleted");
-    else instance_logger.warn("Graph partition and centralstore files deleting failed");
+    if (status == 0)
+        instance_logger.info("Graph partition and centralstore files are now deleted");
+    else
+        instance_logger.warn("Graph partition and centralstore files deleting failed");
     return status;
 }
 
@@ -3098,8 +3110,8 @@ void JasmineGraphInstanceService::createPartitionFiles(std::string graphID, std:
     JasmineGraphHashMapLocalStore *hashMapLocalStore = new JasmineGraphHashMapLocalStore();
     string inputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                            graphID + "_" + partitionID;
-    string outputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" +
-                            graphID + "_" + partitionID;
+    string outputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") +
+                            "/" + graphID + "_" + partitionID;
     if (fileType == "centralstore") {
         inputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID +
                         "_centralstore_" + partitionID;

--- a/src/server/JasmineGraphInstanceService.cpp
+++ b/src/server/JasmineGraphInstanceService.cpp
@@ -398,7 +398,6 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string fileName = (data);
-            // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
             instance_logger.log("Received File name: " + fileName, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_LEN.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_LEN.size());
@@ -487,7 +486,6 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string fileName = (data);
-            // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
             instance_logger.log("Received File name: " + fileName, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_LEN.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_LEN.size());

--- a/src/server/JasmineGraphInstanceService.cpp
+++ b/src/server/JasmineGraphInstanceService.cpp
@@ -63,10 +63,9 @@ void *instanceservicesession(void *dummyPt) {
     int serverDataPort = sessionargs->dataPort;
 
     instance_logger.log("New service session started on thread " + to_string(pthread_self()), "info");
-    Utils utils;
     collector.init();
 
-    utils.createDirectory(utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder"));
+    Utils::createDirectory(Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder"));
 
     char data[INSTANCE_DATA_LENGTH + 1];
     bool loop = false;
@@ -78,10 +77,9 @@ void *instanceservicesession(void *dummyPt) {
         if (line.length() == 0) {
             continue;
         }
-        line = utils.trim_copy(line, " \f\n\r\t\v");
+        line = Utils::trim_copy(line, " \f\n\r\t\v");
 
-        Utils utils;
-        line = utils.trim_copy(line, " \f\n\r\t\v");
+        line = Utils::trim_copy(line, " \f\n\r\t\v");
 
         if (line.compare(JasmineGraphInstanceProtocol::HANDSHAKE) == 0) {
             instance_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE, "info");
@@ -91,7 +89,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             line = (data);
-            line = utils.trim_copy(line, " \f\n\r\t\v");
+            line = Utils::trim_copy(line, " \f\n\r\t\v");
             string server_hostname = line;
             instance_logger.log("Received hostname : " + line, "info");
 
@@ -116,7 +114,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_NAME.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_NAME.size());
@@ -137,11 +135,11 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -170,21 +168,21 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
             string partitionID = rawname.substr(rawname.find_last_of("_") + 1);
             pthread_mutex_lock(&file_lock);
             writeCatalogRecord(graphID + ":" + partitionID);
             pthread_mutex_unlock(&file_lock);
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -209,7 +207,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_NAME.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_NAME.size());
@@ -230,12 +228,12 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -266,16 +264,16 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -299,7 +297,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_NAME.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_NAME.size());
@@ -320,12 +318,12 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -356,16 +354,16 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -389,7 +387,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_NAME.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_NAME.size());
@@ -397,7 +395,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string fileName = (data);
-            // fileName = utils.trim_copy(fileName, " \f\n\r\t\v");
+            // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
             instance_logger.log("Received File name: " + fileName, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_LEN.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_LEN.size());
@@ -410,11 +408,11 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -444,16 +442,16 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -477,7 +475,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_NAME.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_NAME.size());
@@ -485,7 +483,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string fileName = (data);
-            // fileName = utils.trim_copy(fileName, " \f\n\r\t\v");
+            // fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
             instance_logger.log("Received File name: " + fileName, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_FILE_LEN.c_str(),
                   JasmineGraphInstanceProtocol::SEND_FILE_LEN.size());
@@ -498,11 +496,11 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -532,16 +530,16 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -565,7 +563,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             write(connFd, JasmineGraphInstanceProtocol::SEND_PARTITION_ID.c_str(),
                   JasmineGraphInstanceProtocol::SEND_PARTITION_ID.size());
@@ -591,7 +589,7 @@ void *instanceservicesession(void *dummyPt) {
             read(connFd, data, INSTANCE_DATA_LENGTH);
             // Get graph ID from message
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
             // Method call for graph fragment deletion
             removeGraphFragments(graphID);
@@ -608,7 +606,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -617,7 +615,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -626,7 +624,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -646,7 +644,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -655,7 +653,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -664,7 +662,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received WorkerList: " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -725,7 +723,7 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("Elapsed time idd -----------------: " + to_string(elapsed_time_ms), "info");
 
             string instanceDataFolderLocation =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
             string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_idd_" + partitionID;
             ofstream partfile;
             partfile.open(attributeFilePart, std::fstream::trunc);
@@ -743,7 +741,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -752,7 +750,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -761,7 +759,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -785,7 +783,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -794,7 +792,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             map<long, long> degreeDistribution =
@@ -802,7 +800,7 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("Degree Dist size: " + to_string(degreeDistribution.size()), "info");
 
             string instanceDataFolderLocation =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
             string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_odd_" + partitionID;
             ofstream partfile;
             partfile.open(attributeFilePart, std::fstream::trunc);
@@ -818,7 +816,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -827,7 +825,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -836,7 +834,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -860,7 +858,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -869,7 +867,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -878,7 +876,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -894,7 +892,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphVertexCount = (data);
-            graphVertexCount = utils.trim_copy(graphVertexCount, " \f\n\r\t\v");
+            graphVertexCount = Utils::trim_copy(graphVertexCount, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID:" + graphID + " Vertex Count: " + graphVertexCount, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -903,7 +901,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string alphaValue = (data);
-            alphaValue = utils.trim_copy(alphaValue, " \f\n\r\t\v");
+            alphaValue = Utils::trim_copy(alphaValue, " \f\n\r\t\v");
             instance_logger.log("Received alpha: " + alphaValue, "info");
 
             double alpha = std::stod(alphaValue);
@@ -914,7 +912,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string iterationsValue = (data);
-            iterationsValue = utils.trim_copy(iterationsValue, " \f\n\r\t\v");
+            iterationsValue = Utils::trim_copy(iterationsValue, " \f\n\r\t\v");
             instance_logger.log("Received iteration count: " + iterationsValue, "info");
 
             int iterations = std::stoi(iterationsValue);
@@ -963,7 +961,7 @@ void *instanceservicesession(void *dummyPt) {
             }
 
             string instanceDataFolderLocation =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
             string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_pgrnk_" + partitionID;
             ofstream partfile;
             partfile.open(attributeFilePart, std::fstream::trunc);
@@ -985,7 +983,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -994,7 +992,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1003,7 +1001,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -1019,7 +1017,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphVertexCount = (data);
-            graphVertexCount = utils.trim_copy(graphVertexCount, " \f\n\r\t\v");
+            graphVertexCount = Utils::trim_copy(graphVertexCount, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID:" + graphID + " Vertex Count: " + graphVertexCount, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1028,7 +1026,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string alphaValue = (data);
-            alphaValue = utils.trim_copy(alphaValue, " \f\n\r\t\v");
+            alphaValue = Utils::trim_copy(alphaValue, " \f\n\r\t\v");
             instance_logger.log("Received alpha: " + alphaValue, "info");
 
             double alpha = std::stod(alphaValue);
@@ -1039,7 +1037,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string iterationsValue = (data);
-            iterationsValue = utils.trim_copy(iterationsValue, " \f\n\r\t\v");
+            iterationsValue = Utils::trim_copy(iterationsValue, " \f\n\r\t\v");
             instance_logger.log("Received iterations: " + iterationsValue, "info");
 
             int iterations = std::stoi(iterationsValue);
@@ -1088,7 +1086,7 @@ void *instanceservicesession(void *dummyPt) {
             }
 
             string instanceDataFolderLocation =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
             string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_pgrnk_" + partitionID;
             ofstream partfile;
             partfile.open(attributeFilePart, std::fstream::trunc);
@@ -1109,7 +1107,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1118,7 +1116,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1127,7 +1125,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = data;
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1158,7 +1156,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1167,7 +1165,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -1176,7 +1174,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string workerList = (data);
-            workerList = utils.trim_copy(workerList, " \f\n\r\t\v");
+            workerList = Utils::trim_copy(workerList, " \f\n\r\t\v");
             instance_logger.log("Received Worker List " + workerList, "info");
 
             std::vector<string> workerSockets;
@@ -1207,9 +1205,8 @@ void *instanceservicesession(void *dummyPt) {
             map<long, map<long, unordered_set<long>>> egonetMap =
                 calculateLocalEgoNet(graphID, partitionID, serverPort, graphDB, centralDB, workerSockets);
 
-            Utils utils;
             string instanceDataFolderLocation =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
             string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_egonet_" + partitionID;
             ofstream partfile;
             partfile.open(attributeFilePart, std::fstream::trunc);
@@ -1237,21 +1234,21 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionId = (data);
-            partitionId = utils.trim_copy(partitionId, " \f\n\r\t\v");
+            partitionId = Utils::trim_copy(partitionId, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionId, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string priority = (data);
-            priority = utils.trim_copy(priority, " \f\n\r\t\v");
+            priority = Utils::trim_copy(priority, " \f\n\r\t\v");
             instance_logger.log("Received Priority : " + priority, "info");
 
             int threadPriority = std::atoi(priority.c_str());
@@ -1299,12 +1296,12 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -1335,12 +1332,12 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
             std::string aggregatorFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
             DIR *dir = opendir(aggregatorFilePath.c_str());
 
@@ -1359,11 +1356,11 @@ void *instanceservicesession(void *dummyPt) {
 
             std::string movedFullFilePath = aggregatorFilePath + "/" + rawname;
 
-            while (!utils.fileExists(movedFullFilePath)) {
+            while (!Utils::fileExists(movedFullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -1402,12 +1399,12 @@ void *instanceservicesession(void *dummyPt) {
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
 
             int fileSize = atoi(size.c_str());
             while (true) {
-                if (utils.fileExists(fullFilePath)) {
-                    while (utils.getFileSize(fullFilePath) < fileSize) {
+                if (Utils::fileExists(fullFilePath)) {
+                    while (Utils::getFileSize(fullFilePath) < fileSize) {
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(connFd, data, INSTANCE_DATA_LENGTH);
                         line = (data);
@@ -1438,12 +1435,12 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("File received and saved to " + fullFilePath, "info");
             loop = true;
 
-            utils.unzipFile(fullFilePath);
+            Utils::unzipFile(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string rawname = fileName.substr(0, lastindex);
-            fullFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
+            fullFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + rawname;
             std::string aggregatorFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
             DIR *dir = opendir(aggregatorFilePath.c_str());
 
@@ -1462,11 +1459,11 @@ void *instanceservicesession(void *dummyPt) {
 
             std::string movedFullFilePath = aggregatorFilePath + "/" + rawname;
 
-            while (!utils.fileExists(movedFullFilePath)) {
+            while (!Utils::fileExists(movedFullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(connFd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -1490,28 +1487,28 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphId = (data);
-            graphId = utils.trim_copy(graphId, " \f\n\r\t\v");
+            graphId = Utils::trim_copy(graphId, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphId, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionId = (data);
-            partitionId = utils.trim_copy(partitionId, " \f\n\r\t\v");
+            partitionId = Utils::trim_copy(partitionId, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionId, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionIdList = (data);
-            partitionIdList = utils.trim_copy(partitionIdList, " \f\n\r\t\v");
+            partitionIdList = Utils::trim_copy(partitionIdList, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID List : " + partitionIdList, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string priority = (data);
-            priority = utils.trim_copy(priority, " \f\n\r\t\v");
+            priority = Utils::trim_copy(priority, " \f\n\r\t\v");
             instance_logger.log("Received priority: " + priority, "info");
 
             int threadPriority = std::atoi(priority.c_str());
@@ -1569,14 +1566,14 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string availableFiles = (data);
-            availableFiles = utils.trim_copy(availableFiles, " \f\n\r\t\v");
+            availableFiles = Utils::trim_copy(availableFiles, " \f\n\r\t\v");
             instance_logger.log("Received Available Files: " + availableFiles, "info");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             string status = response.substr(response.size() - 5);
             std::string compositeFileList = response.substr(0, response.size() - 5);
@@ -1586,7 +1583,7 @@ void *instanceservicesession(void *dummyPt) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 status = response.substr(response.size() - 5);
                 std::string fileList = response.substr(0, response.size() - 5);
                 compositeFileList = compositeFileList + fileList;
@@ -1599,7 +1596,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string priority = (data);
-            priority = utils.trim_copy(priority, " \f\n\r\t\v");
+            priority = Utils::trim_copy(priority, " \f\n\r\t\v");
             instance_logger.log("Received priority: " + priority, "info");
 
             int threadPriority = std::atoi(priority.c_str());
@@ -1656,14 +1653,14 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string isVMStatManager = (data);
-            isVMStatManager = utils.trim_copy(isVMStatManager, " \f\n\r\t\v");
+            isVMStatManager = Utils::trim_copy(isVMStatManager, " \f\n\r\t\v");
 
             write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::OK, "info");
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string isResourceAllocationRequired = (data);
-            isResourceAllocationRequired = utils.trim_copy(isResourceAllocationRequired, " \f\n\r\t\v");
+            isResourceAllocationRequired = Utils::trim_copy(isResourceAllocationRequired, " \f\n\r\t\v");
 
             std::string memoryUsage = JasmineGraphInstanceService::requestPerformanceStatistics(
                 isVMStatManager, isResourceAllocationRequired);
@@ -1947,19 +1944,19 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string vertexCount = (data);
-            vertexCount = utils.trim_copy(vertexCount, " \f\n\r\t\v");
+            vertexCount = Utils::trim_copy(vertexCount, " \f\n\r\t\v");
             instance_logger.log("Received vertexCount: " + vertexCount, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string ownPartitions = (data);
-            ownPartitions = utils.trim_copy(ownPartitions, " \f\n\r\t\v");
+            ownPartitions = Utils::trim_copy(ownPartitions, " \f\n\r\t\v");
             instance_logger.log("Received Own Partitions No: " + ownPartitions, "info");
 
             /*Receive hosts' detail*/
@@ -2025,9 +2022,9 @@ void *instanceservicesession(void *dummyPt) {
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
 
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
             int fileSize = atoi(size.c_str());
-            while (utils.fileExists(fullFilePath) && utils.getFileSize(fullFilePath) < fileSize) {
+            while (Utils::fileExists(fullFilePath) && Utils::getFileSize(fullFilePath) < fileSize) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 line = (data);
@@ -2056,12 +2053,12 @@ void *instanceservicesession(void *dummyPt) {
             predictargs.push_back(graphID);
             predictargs.push_back(vertexCount);
             predictargs.push_back(fullFilePath);
-            predictargs.push_back(utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
+            predictargs.push_back(Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
             predictargs.push_back(to_string(totalPartitions + stoi(ownPartitions)));
             std::vector<char *> predict_agrs_vector;
             std::transform(predictargs.begin(), predictargs.end(), std::back_inserter(predict_agrs_vector), converter);
 
-            std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.graphsage") + " && ";
+            std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.graphsage") + " && ";
             std::string command = path + "python3.8 predict.py ";
 
             int argc = predictargs.size();
@@ -2080,43 +2077,43 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string serverHostName = (data);
-            serverHostName = utils.trim_copy(serverHostName, " \f\n\r\t\v");
+            serverHostName = Utils::trim_copy(serverHostName, " \f\n\r\t\v");
             instance_logger.log("Received HostName: " + serverHostName, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string serverHostPort = (data);
-            serverHostPort = utils.trim_copy(serverHostPort, " \f\n\r\t\v");
+            serverHostPort = Utils::trim_copy(serverHostPort, " \f\n\r\t\v");
             instance_logger.log("Received Port: " + serverHostPort, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string serverHostDataPort = (data);
-            serverHostDataPort = utils.trim_copy(serverHostDataPort, " \f\n\r\t\v");
+            serverHostDataPort = Utils::trim_copy(serverHostDataPort, " \f\n\r\t\v");
             instance_logger.log("Received Data Port: " + serverHostDataPort, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string graphID = (data);
-            graphID = utils.trim_copy(graphID, " \f\n\r\t\v");
+            graphID = Utils::trim_copy(graphID, " \f\n\r\t\v");
             instance_logger.log("Received Graph ID: " + graphID, "info");
 
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string partitionID = (data);
-            partitionID = utils.trim_copy(partitionID, " \f\n\r\t\v");
+            partitionID = Utils::trim_copy(partitionID, " \f\n\r\t\v");
             instance_logger.log("Received Partition ID: " + partitionID, "info");
 
             std::string fileName = graphID + "_model_" + partitionID;
             std::string filePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" + fileName;
 
             // zip the folder
-            utils.compressDirectory(filePath);
+            Utils::compressDirectory(filePath);
             fileName = fileName + ".tar.gz";
             filePath = filePath + ".tar.gz";
 
-            int fileSize = utils.getFileSize(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
             // send file name
             bzero(data, INSTANCE_DATA_LENGTH + 1);
@@ -2195,7 +2192,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string listOfPartitions = (data);
-            listOfPartitions = utils.trim_copy(listOfPartitions, " \f\n\r\t\v");
+            listOfPartitions = Utils::trim_copy(listOfPartitions, " \f\n\r\t\v");
             instance_logger.log("Received ===>: " + listOfPartitions, "info");
             std::stringstream ss;
             ss << listOfPartitions;
@@ -2222,9 +2219,8 @@ void *instanceservicesession(void *dummyPt) {
                 graphIDs.push_back(graphID);
             }
 
-            Utils utils;
-            string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
-            std::vector<string> listOfFiles = utils.getListOfFilesInDirectory(dataFolder);
+            string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+            std::vector<string> listOfFiles = Utils::getListOfFilesInDirectory(dataFolder);
 
             std::vector<std::string> graphIDsFromFileSystem;
             for (std::vector<string>::iterator x = listOfFiles.begin(); x != listOfFiles.end(); ++x) {
@@ -2288,7 +2284,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string fileType = (data);
-            fileType = utils.trim_copy(fileType, " \f\n\r\t\v");
+            fileType = Utils::trim_copy(fileType, " \f\n\r\t\v");
 
             if (fileType.compare(JasmineGraphInstanceProtocol::FILE_TYPE_CENTRALSTORE_AGGREGATE) == 0) {
                 write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
@@ -2296,23 +2292,23 @@ void *instanceservicesession(void *dummyPt) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string graphId = (data);
-                graphId = utils.trim_copy(graphId, " \f\n\r\t\v");
+                graphId = Utils::trim_copy(graphId, " \f\n\r\t\v");
                 instance_logger.log("Received Graph ID: " + graphId, "info");
 
                 write(connFd, JasmineGraphInstanceProtocol::OK.c_str(), JasmineGraphInstanceProtocol::OK.size());
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string partitionId = (data);
-                partitionId = utils.trim_copy(partitionId, " \f\n\r\t\v");
+                partitionId = Utils::trim_copy(partitionId, " \f\n\r\t\v");
                 instance_logger.log("Received Partition ID: " + partitionId, "info");
 
                 string aggregateLocation =
-                    utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+                    Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
                 string fileName = graphId + "_centralstore_" + partitionId;
                 string fullFilePath = aggregateLocation + "/" + fileName;
                 string result = "false";
 
-                bool fileExists = utils.fileExists(fullFilePath);
+                bool fileExists = Utils::fileExists(fullFilePath);
 
                 if (fileExists) {
                     result = "true";
@@ -2326,15 +2322,15 @@ void *instanceservicesession(void *dummyPt) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(connFd, data, INSTANCE_DATA_LENGTH);
                 string fileName = (data);
-                fileName = utils.trim_copy(fileName, " \f\n\r\t\v");
+                fileName = Utils::trim_copy(fileName, " \f\n\r\t\v");
                 instance_logger.log("Received File name: " + fileName, "info");
 
                 string aggregateLocation =
-                    utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+                    Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
                 string fullFilePath = aggregateLocation + "/" + fileName;
                 string result = "false";
 
-                bool fileExists = utils.fileExists(fullFilePath);
+                bool fileExists = Utils::fileExists(fullFilePath);
 
                 if (fileExists) {
                     result = "true";
@@ -2393,7 +2389,7 @@ void *instanceservicesession(void *dummyPt) {
             bzero(data, INSTANCE_DATA_LENGTH + 1);
             read(connFd, data, INSTANCE_DATA_LENGTH);
             string priority = (data);
-            priority = utils.trim_copy(priority, " \f\n\r\t\v");
+            priority = Utils::trim_copy(priority, " \f\n\r\t\v");
             instance_logger.log("Received Priority: " + priority, "info");
 
             int retrievedPriority = atoi(priority.c_str());
@@ -2488,24 +2484,26 @@ void JasmineGraphInstanceService::run(string profile, string masterHost, string 
     pthread_mutex_destroy(&file_lock);
 }
 
-void deleteGraphPartition(std::string graphID, std::string partitionID) {
-    Utils utils;
-    string partitionFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
+int deleteGraphPartition(std::string graphID, std::string partitionID) {
+    int status = 0;
+    string partitionFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                                graphID + +"_" + partitionID;
-    utils.deleteDirectory(partitionFilePath);
-    string centalStoreFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
+    status |= Utils::deleteDirectory(partitionFilePath);
+    string centalStoreFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                                  graphID + +"_centralstore_" + partitionID;
-    utils.deleteDirectory(centalStoreFilePath);
-    string centalStoreDuplicateFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
+    status |= Utils::deleteDirectory(centalStoreFilePath);
+    string centalStoreDuplicateFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
                                           "/" + graphID + +"_centralstore_dp_" + partitionID;
-    utils.deleteDirectory(centalStoreDuplicateFilePath);
-    string attributeFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
+    status |= Utils::deleteDirectory(centalStoreDuplicateFilePath);
+    string attributeFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                                graphID + +"_attributes_" + partitionID;
-    utils.deleteDirectory(attributeFilePath);
-    string attributeCentalStoreFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
+    status |= Utils::deleteDirectory(attributeFilePath);
+    string attributeCentalStoreFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") +
                                           "/" + graphID + +"_centralstore_attributes_" + partitionID;
-    utils.deleteDirectory(attributeCentalStoreFilePath);
-    instance_logger.log("Graph partition and centralstore files are now deleted", "info");
+    status |= Utils::deleteDirectory(attributeCentalStoreFilePath);
+    if (status == 0) instance_logger.info("Graph partition and centralstore files are now deleted");
+    else instance_logger.warn("Graph partition and centralstore files deleting failed");
+    return status;
 }
 
 /** Method for deleting all graph fragments given a graph ID
@@ -2513,18 +2511,16 @@ void deleteGraphPartition(std::string graphID, std::string partitionID) {
  * @param graphID ID of graph fragments to be deleted in the instance
  */
 void removeGraphFragments(std::string graphID) {
-    Utils utils;
     // Delete all files in the datafolder starting with the graphID
     string partitionFilePath =
-        utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID + "_*";
-    utils.deleteDirectory(partitionFilePath);
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID + "_*";
+    Utils::deleteDirectory(partitionFilePath);
 }
 
 void writeCatalogRecord(string record) {
-    Utils utils;
-    utils.createDirectory(utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder"));
+    Utils::createDirectory(Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder"));
     string catalogFilePath =
-        utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/catalog.txt";
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/catalog.txt";
     ofstream outfile;
     outfile.open(catalogFilePath.c_str(), std::ios_base::app);
     outfile << record << endl;
@@ -2590,8 +2586,7 @@ long countLocalTriangles(
 }
 
 bool JasmineGraphInstanceService::isGraphDBExists(std::string graphId, std::string partitionId) {
-    Utils utils;
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string fileName = dataFolder + "/" + graphId + "_" + partitionId;
     std::ifstream dbFile(fileName, std::ios::binary);
     if (!dbFile) {
@@ -2601,8 +2596,7 @@ bool JasmineGraphInstanceService::isGraphDBExists(std::string graphId, std::stri
 }
 
 bool JasmineGraphInstanceService::isInstanceCentralStoreExists(std::string graphId, std::string partitionId) {
-    Utils utils;
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string filename = dataFolder + "/" + graphId + +"_centralstore_" + partitionId;
     std::ifstream dbFile(filename, std::ios::binary);
     if (!dbFile) {
@@ -2612,8 +2606,7 @@ bool JasmineGraphInstanceService::isInstanceCentralStoreExists(std::string graph
 }
 
 bool JasmineGraphInstanceService::isInstanceDuplicateCentralStoreExists(std::string graphId, std::string partitionId) {
-    Utils utils;
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string filename = dataFolder + "/" + graphId + +"_centralstore_dp_" + partitionId;
     std::ifstream dbFile(filename, std::ios::binary);
     if (!dbFile) {
@@ -2627,8 +2620,7 @@ JasmineGraphIncrementalLocalStore *JasmineGraphInstanceService::loadStreamingSto
     std::map<std::string, JasmineGraphIncrementalLocalStore *> &graphDBMapStreamingStores) {
     std::string graphIdentifier = graphId + "_" + partitionId;
     instance_logger.log("###INSTANCE### Loading streaming Store for" + graphIdentifier + " : Started", "info");
-    Utils utils;
-    std::string folderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string folderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     JasmineGraphIncrementalLocalStore *jasmineGraphStreamingLocalStore =
         new JasmineGraphIncrementalLocalStore(atoi(graphId.c_str()), atoi(partitionId.c_str()));
     graphDBMapStreamingStores.insert(std::make_pair(graphIdentifier, jasmineGraphStreamingLocalStore));
@@ -2642,8 +2634,7 @@ void JasmineGraphInstanceService::loadLocalStore(
     std::map<std::string, JasmineGraphHashMapLocalStore> &graphDBMapLocalStores) {
     instance_logger.log("###INSTANCE### Loading Local Store : Started", "info");
     std::string graphIdentifier = graphId + "_" + partitionId;
-    Utils utils;
-    std::string folderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string folderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     JasmineGraphHashMapLocalStore *jasmineGraphHashMapLocalStore =
         new JasmineGraphHashMapLocalStore(atoi(graphId.c_str()), atoi(partitionId.c_str()), folderLocation);
     jasmineGraphHashMapLocalStore->loadGraph();
@@ -2655,7 +2646,6 @@ void JasmineGraphInstanceService::loadInstanceCentralStore(
     std::map<std::string, JasmineGraphHashMapCentralStore> &graphDBMapCentralStores) {
     instance_logger.log("###INSTANCE### Loading central Store : Started", "info");
     std::string graphIdentifier = graphId + +"_centralstore_" + partitionId;
-    Utils utils;
     JasmineGraphHashMapCentralStore *jasmineGraphHashMapCentralStore =
         new JasmineGraphHashMapCentralStore(atoi(graphId.c_str()), atoi(partitionId.c_str()));
     jasmineGraphHashMapCentralStore->loadGraph();
@@ -2667,7 +2657,6 @@ void JasmineGraphInstanceService::loadInstanceDuplicateCentralStore(
     std::string graphId, std::string partitionId,
     std::map<std::string, JasmineGraphHashMapDuplicateCentralStore> &graphDBMapDuplicateCentralStores) {
     std::string graphIdentifier = graphId + +"_centralstore_dp_" + partitionId;
-    Utils utils;
     JasmineGraphHashMapDuplicateCentralStore *jasmineGraphHashMapCentralStore =
         new JasmineGraphHashMapDuplicateCentralStore(atoi(graphId.c_str()), atoi(partitionId.c_str()));
     jasmineGraphHashMapCentralStore->loadGraph();
@@ -2685,12 +2674,11 @@ JasmineGraphHashMapCentralStore JasmineGraphInstanceService::loadCentralStore(st
 std::string JasmineGraphInstanceService::copyCentralStoreToAggregator(std::string graphId, std::string partitionId,
                                                                       std::string aggregatorHost,
                                                                       std::string aggregatorPort, std::string host) {
-    Utils utils;
     char buffer[128];
     std::string result = "SUCCESS";
     std::string centralGraphIdentifier = graphId + +"_centralstore_" + partitionId;
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
     if (JasmineGraphInstanceService::isInstanceCentralStoreExists(graphId, partitionId)) {
         std::string centralStoreFile = dataFolder + "/" + centralGraphIdentifier;
@@ -2733,13 +2721,12 @@ std::string JasmineGraphInstanceService::copyCentralStoreToAggregator(std::strin
 
 string JasmineGraphInstanceService::aggregateCentralStoreTriangles(std::string graphId, std::string partitionId,
                                                                    std::string partitionIdList, int threadPriority) {
-    Utils utils;
     instance_logger.log("###INSTANCE### Started Aggregating Central Store Triangles", "info");
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
     std::vector<std::string> fileNames;
     map<long, unordered_set<long>> aggregatedCentralStore;
     std::string centralGraphIdentifier = graphId + +"_centralstore_" + partitionId;
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string workerCentralStoreFile = dataFolder + "/" + centralGraphIdentifier;
     instance_logger.log("###INSTANCE### Loading Central Store : Started " + workerCentralStoreFile, "info");
     JasmineGraphHashMapCentralStore workerCentralStore =
@@ -2805,10 +2792,9 @@ string JasmineGraphInstanceService::aggregateCentralStoreTriangles(std::string g
 string JasmineGraphInstanceService::aggregateCompositeCentralStoreTriangles(std::string compositeFileList,
                                                                             std::string availableFileList,
                                                                             int threadPriority) {
-    Utils utils;
     instance_logger.log("###INSTANCE### Started Aggregating Composite Central Store Triangles", "info");
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
-    std::string dataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string dataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     map<long, unordered_set<long>> aggregatedCompositeCentralStore;
 
     std::vector<std::string> compositeCentralStoreFileList = Utils::split(compositeFileList, ':');
@@ -2899,7 +2885,6 @@ map<long, long> JasmineGraphInstanceService::getOutDegreeDistributionHashMap(map
 
 string JasmineGraphInstanceService::requestPerformanceStatistics(std::string isVMStatManager,
                                                                  std::string isResourceAllocationRequested) {
-    Utils utils;
     int memoryUsage = collector.getMemoryUsageByProcess();
     double cpuUsage = collector.getCpuUsage();
     double loadAverage = collector.getLoadAverage();
@@ -2907,7 +2892,7 @@ string JasmineGraphInstanceService::requestPerformanceStatistics(std::string isV
     auto executedTime = std::chrono::system_clock::now();
     std::time_t reportTime = std::chrono::system_clock::to_time_t(executedTime);
     std::string reportTimeString(std::ctime(&reportTime));
-    reportTimeString = utils.trim_copy(reportTimeString, " \f\n\r\t\v");
+    reportTimeString = Utils::trim_copy(reportTimeString, " \f\n\r\t\v");
     std::string usageString =
         reportTimeString + "," + to_string(memoryUsage) + "," + to_string(cpuUsage) + "," + to_string(loadAverage);
     if (!vmLevelStatistics.empty()) {
@@ -2944,7 +2929,6 @@ void JasmineGraphInstanceService::collectTrainedModels(
 int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservicesessionargs *sessionargs,
                                                                    std::string host, int port, int dataPort,
                                                                    std::string graphID, std::string partition) {
-    Utils utils;
     bool result = true;
     std::cout << pthread_self() << " host : " << host << " port : " << port << " DPort : " << dataPort << std::endl;
     int sockfd;
@@ -2962,7 +2946,7 @@ int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservi
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -2985,7 +2969,7 @@ int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservi
     read(sockfd, data, INSTANCE_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         instance_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
 
@@ -3000,7 +2984,7 @@ int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservi
         bzero(data, INSTANCE_DATA_LENGTH + 1);
         read(sockfd, data, INSTANCE_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             instance_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3043,9 +3027,9 @@ int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservi
                   JasmineGraphInstanceProtocol::SEND_FILE_CONT.size());
             instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
             string fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + fileName;
             int fileSize = atoi(size.c_str());
-            while (utils.fileExists(fullFilePath) && utils.getFileSize(fullFilePath) < fileSize) {
+            while (Utils::fileExists(fullFilePath) && Utils::getFileSize(fullFilePath) < fileSize) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(sockfd, data, INSTANCE_DATA_LENGTH);
                 response = (data);
@@ -3067,19 +3051,19 @@ int JasmineGraphInstanceService::collectTrainedModelThreadFunction(instanceservi
                 instance_logger.log("Sent : " + JasmineGraphInstanceProtocol::FILE_ACK, "info");
             }
 
-            utils.unzipDirectory(fullFilePath);
+            Utils::unzipDirectory(fullFilePath);
             size_t lastindex = fileName.find_last_of(".");
             string pre_rawname = fileName.substr(0, lastindex);
             size_t next_lastindex = pre_rawname.find_last_of(".");
             string rawname = fileName.substr(0, next_lastindex);
             fullFilePath =
-                utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" + rawname;
+                Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" + rawname;
 
-            while (!utils.fileExists(fullFilePath)) {
+            while (!Utils::fileExists(fullFilePath)) {
                 bzero(data, INSTANCE_DATA_LENGTH + 1);
                 read(sockfd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 if (response.compare(JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::BATCH_UPLOAD_CHK, "info");
                     write(sockfd, JasmineGraphInstanceProtocol::BATCH_UPLOAD_WAIT.c_str(),
@@ -3110,17 +3094,16 @@ void JasmineGraphInstanceService::createPartitionFiles(std::string graphID, std:
                                                        std::string fileType) {
     instance_logger.log(fileType, "info");
 
-    Utils utils;
-    utils.createDirectory(utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
+    Utils::createDirectory(Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder"));
     JasmineGraphHashMapLocalStore *hashMapLocalStore = new JasmineGraphHashMapLocalStore();
-    string inputFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
+    string inputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" +
                            graphID + "_" + partitionID;
-    string outputFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" +
+    string outputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" +
                             graphID + "_" + partitionID;
     if (fileType == "centralstore") {
-        inputFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID +
+        inputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + "/" + graphID +
                         "_centralstore_" + partitionID;
-        outputFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" +
+        outputFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + "/" +
                          graphID + "_centralstore_" + partitionID;
     }
     std::map<int, std::vector<int>> partEdgeMap = hashMapLocalStore->getEdgeHashMap(inputFilePath);
@@ -3201,7 +3184,6 @@ void JasmineGraphInstanceService::executeTrainingIterations(int maxThreads) {
 }
 
 void JasmineGraphInstanceService::trainPartition(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     string graphID;
     string partitionID = trainargs[trainargs.size() - 1];
@@ -3216,7 +3198,7 @@ void JasmineGraphInstanceService::trainPartition(string trainData) {
     std::vector<char *> vc;
     std::transform(trainargs.begin(), trainargs.end(), std::back_inserter(vc), converter);
 
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.graphsage") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.graphsage") + " && ";
     std::string command =
         path + "python3.8 -m unsupervised_train >  /home/ubuntu/software/jasminegraph/logs/unsupervised_train" +
         partitionID + "-" + Utils::getCurrentTimestamp() + ".txt";
@@ -3271,19 +3253,18 @@ map<long, long> JasmineGraphInstanceService::calculateLocalOutDegreeDistribution
 
 bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int graphID, int partitionID,
                                                         std::vector<string> workerSockets, std::string masterIP) {
-    Utils utils;
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
-    std::string dataFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string dataFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
 
     std::string centralGraphIdentifierUnCompressed = to_string(graphID) + "_centralstore_" + to_string(partitionID);
     std::string centralStoreFileUnCompressed = dataFilePath + "/" + centralGraphIdentifierUnCompressed;
     std::string centralStoreFileUnCompressedDestination = aggregatorFilePath + "/" + centralGraphIdentifierUnCompressed;
 
     // temporary copy the central store into the aggregate folder in order to compress and send
-    utils.copyFile(centralStoreFileUnCompressed, aggregatorFilePath);
+    Utils::copyFile(centralStoreFileUnCompressed, aggregatorFilePath);
 
     // compress the central store file before sending
-    utils.compressFile(centralStoreFileUnCompressedDestination);
+    Utils::compressFile(centralStoreFileUnCompressedDestination);
 
     std::string centralGraphIdentifier = to_string(graphID) + "_centralstore_" + to_string(partitionID) + ".gz";
     std::string centralStoreFile = aggregatorFilePath + "/" + centralGraphIdentifier;
@@ -3314,7 +3295,6 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
                     continue;
                 }
 
-                Utils utils;
                 bool result = true;
                 std::cout << pthread_self() << " host : " << host << " port : " << port << " DPort : " << dataPort
                           << std::endl;
@@ -3333,7 +3313,7 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
                 }
 
                 if (host.find('@') != std::string::npos) {
-                    host = utils.split(host, '@')[1];
+                    host = Utils::split(host, '@')[1];
                 }
 
                 server = gethostbyname(host.c_str());
@@ -3363,7 +3343,7 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
                 read(sockfd, data, INSTANCE_DATA_LENGTH);
                 string response = (data);
 
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -3396,7 +3376,7 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
                     bzero(data, INSTANCE_DATA_LENGTH + 1);
                     read(sockfd, data, INSTANCE_DATA_LENGTH);
                     response = (data);
-                    response = utils.trim_copy(response, " \f\n\r\t\v");
+                    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                         instance_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3407,14 +3387,14 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
                         }
 
                         instance_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-                        std::string fileName = utils.getFileName(centralStoreFile);
-                        int fileSize = utils.getFileSize(centralStoreFile);
+                        std::string fileName = Utils::getFileName(centralStoreFile);
+                        int fileSize = Utils::getFileSize(centralStoreFile);
                         std::string fileLength = to_string(fileSize);
 
                         bzero(data, INSTANCE_DATA_LENGTH + 1);
                         read(sockfd, data, INSTANCE_DATA_LENGTH);
                         response = (data);
-                        response = utils.trim_copy(response, " \f\n\r\t\v");
+                        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                         if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                             instance_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -3519,7 +3499,6 @@ bool JasmineGraphInstanceService::duplicateCentralStore(int thisWorkerPort, int 
 
 bool JasmineGraphInstanceService::sendFileThroughService(std::string host, int dataPort, std::string fileName,
                                                          std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[INSTANCE_DATA_LENGTH + 1];
     socklen_t len;
@@ -3556,7 +3535,7 @@ bool JasmineGraphInstanceService::sendFileThroughService(std::string host, int d
     bzero(data, INSTANCE_DATA_LENGTH + 1);
     read(sockfd, data, INSTANCE_DATA_LENGTH);
     string response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE) == 0) {
         std::cout << "Sending file " << filePath << " through port " << dataPort << std::endl;
@@ -3598,11 +3577,10 @@ map<long, long> calculateOutDegreeDist(string graphID, string partitionID, int s
                                        std::map<std::string, JasmineGraphHashMapLocalStore> graphDBMapLocalStores,
                                        std::map<std::string, JasmineGraphHashMapCentralStore> graphDBMapCentralStores,
                                        std::vector<string> workerSockets) {
-    Utils utils;
     map<long, long> degreeDistribution =
         calculateLocalOutDegreeDist(graphID, partitionID, graphDBMapLocalStores, graphDBMapCentralStores);
 
-    string instanceDataFolderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    string instanceDataFolderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_odd_" + partitionID;
     ofstream partfile;
     partfile.open(attributeFilePart, std::fstream::trunc);
@@ -3689,8 +3667,6 @@ map<long, long> calculateInDegreeDist(string graphID, string partitionID, int se
                                       std::map<std::string, JasmineGraphHashMapLocalStore> graphDBMapLocalStores,
                                       std::map<std::string, JasmineGraphHashMapCentralStore> graphDBMapCentralStores,
                                       std::vector<string> workerSockets, string workerList) {
-    Utils utils;
-
     auto t_start = std::chrono::high_resolution_clock::now();
 
     map<long, long> degreeDistribution =
@@ -3742,7 +3718,7 @@ map<long, long> calculateInDegreeDist(string graphID, string partitionID, int se
 
     instance_logger.log("In Degree Dist size: " + to_string(degreeDistribution.size()), "info");
 
-    string instanceDataFolderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    string instanceDataFolderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_idd_" + partitionID;
     ofstream partfile;
     partfile.open(attributeFilePart, std::fstream::trunc);
@@ -3823,8 +3799,7 @@ map<long, map<long, unordered_set<long>>> calculateLocalEgoNet(string graphID, s
             workerSocketPair.push_back(intermediate);
         }
 
-        Utils utils;
-        std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+        std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
         std::string centralGraphIdentifier = graphID + +"_centralstore_" + workerSocketPair[2];
 
         std::string centralStoreFile = aggregatorFilePath + "/" + centralGraphIdentifier;
@@ -3874,8 +3849,7 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
     map<long, map<long, unordered_set<long>>> egonetMap =
         calculateLocalEgoNet(graphID, partitionID, serverPort, localDB, centralDB, workerSockets);
 
-    Utils utils;
-    string instanceDataFolderLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    string instanceDataFolderLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     string attributeFilePart = instanceDataFolderLocation + "/" + graphID + "_egonet_" + partitionID;
     ofstream partfile;
     partfile.open(attributeFilePart, std::fstream::trunc);
@@ -3907,7 +3881,6 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
             continue;
         }
 
-        Utils utils;
         string host = workerSocketPair[0];
         int port = stoi(workerSocketPair[1]);
         int sockfd;
@@ -3950,7 +3923,7 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
         bzero(data, 301);
         read(sockfd, data, 300);
         string response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             instance_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3964,7 +3937,7 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
             bzero(data, 301);
             read(sockfd, data, 300);
             string response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                 instance_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3982,7 +3955,7 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (!response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                     instance_logger.log("Error reading from socket", "error");
@@ -3999,7 +3972,7 @@ void calculateEgoNet(string graphID, string partitionID, int serverPort, Jasmine
                 bzero(data, 301);
                 read(sockfd, data, 300);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                     instance_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -4064,8 +4037,7 @@ map<long, double> calculateLocalPageRank(string graphID, double alpha, string pa
 
     map<long, long> inDegreeDistribution;
 
-    Utils utils;
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     std::string iddFilePath = aggregatorFilePath + "/" + graphID + +"_idd_" + partitionID;
     ifstream dataFile;
     dataFile.open(iddFilePath);
@@ -4181,8 +4153,7 @@ map<long, unordered_set<long>> getEdgesWorldToLocal(string graphID, string parti
             workerSocketPair.push_back(intermediate);
         }
 
-        Utils utils;
-        std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+        std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
         std::string centralGraphIdentifier = graphID + +"_centralstore_" + workerSocketPair[2];
 
         std::string centralStoreFile = aggregatorFilePath + "/" + centralGraphIdentifier;
@@ -4242,7 +4213,6 @@ void JasmineGraphInstanceService::startCollectingLoadAverage() {
 }
 
 void JasmineGraphInstanceService::initServer(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     string graphID;
     string partitionID = trainargs[trainargs.size() - 1];
@@ -4258,13 +4228,13 @@ void JasmineGraphInstanceService::initServer(string trainData) {
     std::transform(trainargs.begin(), trainargs.end(), std::back_inserter(vc), converter);
 
     std::string log_file = "/tmp/jasminegraph/fl_server_" + partitionID + ".log";
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
     std::string command =
-        path + "python3.8 fl_server.py " + utils.getJasmineGraphProperty("org.jasminegraph.fl.weights") + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " 0 " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl_clients") + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost 5000" + " >>" + log_file + " 2>&1";
+        path + "python3.8 fl_server.py " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.weights") + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " 0 " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl_clients") + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost 5000" + " >>" + log_file + " 2>&1";
     instance_logger.log("Executing : " + command, "info");
     int exit_status = system(command.c_str());
     chmod(log_file.c_str(), 0666);
@@ -4274,7 +4244,6 @@ void JasmineGraphInstanceService::initServer(string trainData) {
 }
 
 void JasmineGraphInstanceService::initOrgServer(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     std::string graphID;
     string partitionID = trainargs[trainargs.size() - 1];
@@ -4289,10 +4258,10 @@ void JasmineGraphInstanceService::initOrgServer(string trainData) {
     std::vector<char *> vc;
     std::transform(trainargs.begin(), trainargs.end(), std::back_inserter(vc), converter);
 
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
     std::string command = path + "python3.8 org_server.py " + graphID + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl_clients") + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.epochs") +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl_clients") + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.epochs") +
                           " localhost 5050 > /home/ubuntu/software/jasminegraph/logs/org_server_logs-" +
                           Utils::getCurrentTimestamp() + ".txt";
     instance_logger.log("Executing : " + command, "info");
@@ -4303,7 +4272,6 @@ void JasmineGraphInstanceService::initOrgServer(string trainData) {
 }
 
 void JasmineGraphInstanceService::initAgg(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     string graphID;
     string partitionID = trainargs[trainargs.size() - 1];
@@ -4318,12 +4286,12 @@ void JasmineGraphInstanceService::initAgg(string trainData) {
     std::vector<char *> vc;
     std::transform(trainargs.begin(), trainargs.end(), std::back_inserter(vc), converter);
 
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
     std::string command = path + "python3.8 org_agg.py " + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + "4" + " 0 " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.num.orgs") + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost 5000 > " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + "4" + " 0 " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.num.orgs") + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost 5000 > " +
                           "/home/ubuntu/software/jasminegraph/logs/agg_logs-" + Utils::getCurrentTimestamp() + ".txt";
     instance_logger.log("Executing : " + command, "info");
     int exit_status = system(command.c_str());
@@ -4333,7 +4301,6 @@ void JasmineGraphInstanceService::initAgg(string trainData) {
 }
 
 void JasmineGraphInstanceService::initClient(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     string graphID;
     string partitionID = trainargs[trainargs.size() - 1];
@@ -4349,13 +4316,13 @@ void JasmineGraphInstanceService::initClient(string trainData) {
     std::transform(trainargs.begin(), trainargs.end(), std::back_inserter(vc), converter);
 
     std::string log_file = "/tmp/jasminegraph/fl_client_" + partitionID + ".log";
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
     std::string command =
-        path + "python3.8 fl_client.py " + utils.getJasmineGraphProperty("org.jasminegraph.fl.weights") + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " " + partitionID + " " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost " +
-        utils.getJasmineGraphProperty("org.jasminegraph.fl.org.port") + " >>" + log_file + " 2>&1";
+        path + "python3.8 fl_client.py " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.weights") + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " " + partitionID + " " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.epochs") + " localhost " +
+        Utils::getJasmineGraphProperty("org.jasminegraph.fl.org.port") + " >>" + log_file + " 2>&1";
 
     instance_logger.log("Executing : " + command, "info");
     int exit_status = system(command.c_str());
@@ -4366,18 +4333,17 @@ void JasmineGraphInstanceService::initClient(string trainData) {
 }
 
 void JasmineGraphInstanceService::mergeFiles(string trainData) {
-    Utils utils;
     std::vector<std::string> trainargs = Utils::split(trainData, ' ');
     string graphID = trainargs[1];
     string partitionID = trainargs[2];
     int exit_status;
 
     std::string log_file = "/tmp/jasminegraph/merge_" + partitionID + ".log";
-    std::string path = "cd " + utils.getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
+    std::string path = "cd " + Utils::getJasmineGraphProperty("org.jasminegraph.fl.location") + " && ";
     std::string command = path + "python3.8 merge.py " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + " " +
-                          utils.getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder") + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder") + " " +
+                          Utils::getJasmineGraphProperty("org.jasminegraph.fl.dataDir") + " " + graphID + " " +
                           partitionID + " >>" + log_file + " 2>&1";
 
     instance_logger.log("Executing : " + command, "info");

--- a/src/server/JasmineGraphInstanceService.h
+++ b/src/server/JasmineGraphInstanceService.h
@@ -48,7 +48,7 @@ limitations under the License.
 
 void* instanceservicesession(void* dummyPt);
 void writeCatalogRecord(string record);
-void deleteGraphPartition(std::string graphID, std::string partitionID);
+int deleteGraphPartition(std::string graphID, std::string partitionID);
 void removeGraphFragments(std::string graphID);
 long countLocalTriangles(
     std::string graphId, std::string partitionId,

--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -971,7 +971,6 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -985,7 +984,6 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1164,7 +1162,6 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1178,7 +1175,6 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1202,7 +1198,6 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1398,7 +1393,6 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1412,7 +1406,6 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1436,7 +1429,6 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1594,7 +1586,6 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1608,7 +1599,6 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1632,7 +1622,6 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");

--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -284,7 +284,8 @@ void JasmineGraphServer::startRemoteWorkers(std::vector<int> workerPortsVector, 
     std::string workerPath = Utils::getJasmineGraphProperty("org.jasminegraph.worker.path");
     std::string artifactPath = Utils::getJasmineGraphProperty("org.jasminegraph.artifact.path");
     std::string instanceDataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
-    std::string aggregateDataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string aggregateDataFolder =
+        Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
     std::string nmonFileLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.nmon.file.location");
     std::string graphsagelocation = Utils::getJasmineGraphProperty("org.jasminegraph.graphsage");
     std::string federatedLearningLocation = Utils::getJasmineGraphProperty("org.jasminegraph.fl.location");

--- a/src/server/JasmineGraphServer.cpp
+++ b/src/server/JasmineGraphServer.cpp
@@ -60,7 +60,6 @@ JasmineGraphServer::~JasmineGraphServer() {
 int JasmineGraphServer::run(std::string profile, std::string masterIp, int numberofWorkers, std::string workerIps,
                             std::string enableNmon) {
     server_logger.log("Running the server...", "info");
-    Utils utils;
     std::vector<int> masterPortVector;
 
     this->sqlite = *new SQLiteDBInterface();
@@ -70,7 +69,7 @@ int JasmineGraphServer::run(std::string profile, std::string masterIp, int numbe
     this->jobScheduler = *new JobScheduler(this->sqlite, this->performanceSqlite);
     this->jobScheduler.init();
     if (masterIp.empty()) {
-        this->masterHost = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        this->masterHost = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
     } else {
         this->masterHost = masterIp;
     }
@@ -95,8 +94,6 @@ int JasmineGraphServer::run(std::string profile, std::string masterIp, int numbe
 bool JasmineGraphServer::isRunning() { return true; }
 
 void JasmineGraphServer::init() {
-    Utils utils;
-
     pthread_t frontendthread;
     pthread_t backendthread;
     pthread_create(&frontendthread, NULL, runfrontend, this);
@@ -104,17 +101,16 @@ void JasmineGraphServer::init() {
 }
 
 void JasmineGraphServer::start_workers() {
-    Utils utils;
     int hostListModeNWorkers = 0;
     int numberOfWorkersPerHost;
     std::vector<std::string> hostsList;
     std::string nWorkers;
     if (profile == "native") {
-        hostsList = utils.getHostListFromProperties();
+        hostsList = Utils::getHostListFromProperties();
         if ((this->numberOfWorkers) == -1) {
-            nWorkers = utils.getJasmineGraphProperty("org.jasminegraph.server.nworkers");
+            nWorkers = Utils::getJasmineGraphProperty("org.jasminegraph.server.nworkers");
         }
-        enableNmon = utils.getJasmineGraphProperty("org.jasminegraph.server.enable.nmon");
+        enableNmon = Utils::getJasmineGraphProperty("org.jasminegraph.server.enable.nmon");
     } else if (profile == "docker") {
         hostsList = getWorkerVector(workerHosts);
     }
@@ -137,7 +133,7 @@ void JasmineGraphServer::start_workers() {
         std::string ip_address = "";
         std::string user = "";
         if (hostItem.find('@') != std::string::npos) {
-            vector<string> splitted = utils.split(hostItem, '@');
+            vector<string> splitted = Utils::split(hostItem, '@');
             ip_address = splitted[1];
             user = splitted[0];
         } else {
@@ -155,7 +151,7 @@ void JasmineGraphServer::start_workers() {
     int workerDataPort = Conts::JASMINEGRAPH_INSTANCE_DATA_PORT;
 
     if (this->numberOfWorkers == -1) {
-        if (utils.is_number(nWorkers)) {
+        if (Utils::is_number(nWorkers)) {
             numberOfWorkers = atoi(nWorkers.c_str());
         }
     }
@@ -170,7 +166,7 @@ void JasmineGraphServer::start_workers() {
         hostListModeNWorkers = numberOfWorkers % hostsList.size();
     }
 
-    std::string schedulerEnabled = utils.getJasmineGraphProperty("org.jasminegraph.scheduler.enabled");
+    std::string schedulerEnabled = Utils::getJasmineGraphProperty("org.jasminegraph.scheduler.enabled");
 
     if (schedulerEnabled == "true") {
         backupPerformanceDB();
@@ -190,7 +186,7 @@ void JasmineGraphServer::start_workers() {
         string user = "";
         string ip = hostName;
         if (hostName.find('@') != std::string::npos) {
-            vector<string> splitted = utils.split(hostName, '@');
+            vector<string> splitted = Utils::split(hostName, '@');
             ip = splitted[1];
             user = splitted[0];
         }
@@ -284,18 +280,17 @@ void JasmineGraphServer::waitForAcknowledgement(int numberOfWorkers) {
 
 void JasmineGraphServer::startRemoteWorkers(std::vector<int> workerPortsVector, std::vector<int> workerDataPortsVector,
                                             string host, string profile, string masterHost, string enableNmon) {
-    Utils utils;
     std::string executableFile;
-    std::string workerPath = utils.getJasmineGraphProperty("org.jasminegraph.worker.path");
-    std::string artifactPath = utils.getJasmineGraphProperty("org.jasminegraph.artifact.path");
-    std::string instanceDataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
-    std::string aggregateDataFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
-    std::string nmonFileLocation = utils.getJasmineGraphProperty("org.jasminegraph.server.nmon.file.location");
-    std::string graphsagelocation = utils.getJasmineGraphProperty("org.jasminegraph.graphsage");
-    std::string federatedLearningLocation = utils.getJasmineGraphProperty("org.jasminegraph.fl.location");
+    std::string workerPath = Utils::getJasmineGraphProperty("org.jasminegraph.worker.path");
+    std::string artifactPath = Utils::getJasmineGraphProperty("org.jasminegraph.artifact.path");
+    std::string instanceDataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    std::string aggregateDataFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string nmonFileLocation = Utils::getJasmineGraphProperty("org.jasminegraph.server.nmon.file.location");
+    std::string graphsagelocation = Utils::getJasmineGraphProperty("org.jasminegraph.graphsage");
+    std::string federatedLearningLocation = Utils::getJasmineGraphProperty("org.jasminegraph.fl.location");
 
-    std::string instanceFolder = utils.getJasmineGraphProperty("org.jasminegraph.server.instance");
-    std::string instanceFolderLocal = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.local");
+    std::string instanceFolder = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance");
+    std::string instanceFolderLocal = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.local");
 
     std::string jasmineGraphExecutableName = Conts::JASMINEGRAPH_EXECUTABLE;
     server_logger.log("###MASTER#### Starting remote workers for profile " + profile, "info");
@@ -309,7 +304,7 @@ void JasmineGraphServer::startRemoteWorkers(std::vector<int> workerPortsVector, 
     std::string result = "";
 
     if (artifactPath.empty() || artifactPath.find_first_not_of(' ') == artifactPath.npos) {
-        artifactPath = utils.getJasmineGraphHome();
+        artifactPath = Utils::getJasmineGraphHome();
     }
 
     if (profile == "native") {
@@ -512,7 +507,6 @@ void JasmineGraphServer::resolveOperationalGraphs() {
     sqlStatement = "SELECT idworker,ip,server_port FROM worker";
     output = sqlite.runSelect(sqlStatement);
 
-    Utils utils;
     std::set<int> graphIDsFromWorkersSet;
     for (std::vector<vector<pair<string, string>>>::iterator i = output.begin(); i != output.end(); ++i) {
         int workerID = -1;
@@ -540,7 +534,7 @@ void JasmineGraphServer::resolveOperationalGraphs() {
         }
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         server = gethostbyname(host.c_str());
@@ -570,11 +564,11 @@ void JasmineGraphServer::resolveOperationalGraphs() {
         read(sockfd, data, FED_DATA_LENGTH);
         string response = (data);
 
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-            string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+            string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
             result_wr = write(sockfd, server_host.c_str(), server_host.size());
 
             if (result_wr < 0) {
@@ -594,7 +588,7 @@ void JasmineGraphServer::resolveOperationalGraphs() {
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
@@ -612,7 +606,7 @@ void JasmineGraphServer::resolveOperationalGraphs() {
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    response = utils.trim_copy(response, " \f\n\r\t\v");
+                    response = Utils::trim_copy(response, " \f\n\r\t\v");
                     server_logger.log("Received : " + response, "info");
 
                     if (response.compare(JasmineGraphInstanceProtocol::FRAGMENT_RESOLUTION_CHK) == 0) {
@@ -635,11 +629,11 @@ void JasmineGraphServer::resolveOperationalGraphs() {
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    response = utils.trim_copy(response, " \f\n\r\t\v");
+                    response = Utils::trim_copy(response, " \f\n\r\t\v");
                     server_logger.log("Received : " + response, "info");
 
                     if (response.compare("") != 0) {
-                        std::vector<string> listOfOitems = utils.split(response, ',');
+                        std::vector<string> listOfOitems = Utils::split(response, ',');
                         for (std::vector<string>::iterator it = listOfOitems.begin(); it != listOfOitems.end(); it++) {
                             graphIDsFromWorkersSet.insert(atoi(it->c_str()));
                         }
@@ -699,7 +693,6 @@ void JasmineGraphServer::shutdown_workers() {
     std::vector<workers, std::allocator<workers>>::iterator mapIterator;
     for (mapIterator = hostWorkerMap.begin(); mapIterator < hostWorkerMap.end(); mapIterator++) {
         workers worker = *mapIterator;
-        Utils utils;
         bool result = true;
         std::cout << pthread_self() << " host : " << worker.hostname << " port : " << worker.port
                   << " DPort : " << worker.dataPort << std::endl;
@@ -721,7 +714,7 @@ void JasmineGraphServer::shutdown_workers() {
         int port = worker.port;
 
         if (worker.hostname.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         server = gethostbyname(host.c_str());
@@ -745,7 +738,7 @@ void JasmineGraphServer::shutdown_workers() {
         read(sockfd, data, FED_DATA_LENGTH);
         string response = (data);
 
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         server_logger.log("Response : " + response, "info");
     }
 }
@@ -759,9 +752,8 @@ void JasmineGraphServer::uploadGraphLocally(int graphID, const string graphType,
     std::map<int, string> compositeCentralStoreFileList = fullFileList[5];
     std::map<int, string> attributeFileList;
     std::map<int, string> centralStoreAttributeFileList;
-    Utils utils;
     if (masterHost.empty()) {
-        masterHost = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        masterHost = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
     }
     int total_threads = partitionFileList.size() + centralStoreFileList.size() + centralStoreDuplFileList.size() +
                         compositeCentralStoreFileList.size();
@@ -839,14 +831,13 @@ void JasmineGraphServer::uploadGraphLocally(int graphID, const string graphType,
 void JasmineGraphServer::assignPartitionToWorker(std::string fileName, int graphId, std::string workerHost,
                                                  int workerPort, int workerDataPort) {
     SQLiteDBInterface refToSqlite = *new SQLiteDBInterface();
-    Utils utils;
     refToSqlite.init();
     size_t lastindex = fileName.find_last_of(".");
     string rawname = fileName.substr(0, lastindex);
     string partitionID = rawname.substr(rawname.find_last_of("_") + 1);
 
     if (workerHost.find('@') != std::string::npos) {
-        workerHost = utils.split(workerHost, '@')[1];
+        workerHost = Utils::split(workerHost, '@')[1];
     }
 
     std::string workerSearchQuery = "select idworker from worker where ip='" + workerHost + "' and server_port='" +
@@ -867,7 +858,6 @@ void JasmineGraphServer::assignPartitionToWorker(std::string fileName, int graph
 
 bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPort, int graphID, std::string filePath,
                                          std::string masterIP) {
-    Utils utils;
     bool result = true;
     std::cout << pthread_self() << " host : " << host << " port : " << port << " DPort : " << dataPort << std::endl;
     int sockfd;
@@ -885,7 +875,7 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -915,7 +905,7 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -947,7 +937,7 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -959,14 +949,14 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
             }
 
             server_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -980,7 +970,7 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -994,7 +984,7 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = utils.trim_copy(response, " \f\n\r\t\v");
+                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1065,7 +1055,6 @@ bool JasmineGraphServer::batchUploadFile(std::string host, int port, int dataPor
 
 bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int dataPort, int graphID,
                                                  std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
     struct sockaddr_in serv_addr;
@@ -1079,7 +1068,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1108,7 +1097,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1140,7 +1129,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1152,14 +1141,14 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
             }
 
             server_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1174,7 +1163,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1188,7 +1177,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = utils.trim_copy(response, " \f\n\r\t\v");
+                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1212,7 +1201,7 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1261,11 +1250,10 @@ bool JasmineGraphServer::batchUploadCentralStore(std::string host, int port, int
 }
 
 void JasmineGraphServer::copyCentralStoreToAggregateLocation(std::string filePath) {
-    Utils utils;
     char buffer[128];
     std::string result = "SUCCESS";
     std::string copyCommand;
-    std::string aggregatorFilePath = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
+    std::string aggregatorFilePath = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.aggregatefolder");
 
     DIR *dir = opendir(aggregatorFilePath.c_str());
 
@@ -1294,14 +1282,13 @@ void JasmineGraphServer::copyCentralStoreToAggregateLocation(std::string filePat
         pclose(copyInput);
     }
 
-    std::string fileName = utils.getFileName(filePath);
+    std::string fileName = Utils::getFileName(filePath);
 
     std::string fullFileName = aggregatorFilePath + "/" + fileName;
 }
 
 bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, int dataPort, int graphID,
                                                   std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
     struct sockaddr_in serv_addr;
@@ -1315,7 +1302,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1344,7 +1331,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1376,7 +1363,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         // std::cout << response << std::endl;
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1388,14 +1375,14 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
             }
 
             server_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1410,7 +1397,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1424,7 +1411,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = utils.trim_copy(response, " \f\n\r\t\v");
+                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1448,7 +1435,7 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1498,7 +1485,6 @@ bool JasmineGraphServer::batchUploadAttributeFile(std::string host, int port, in
 
 bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int port, int dataPort, int graphID,
                                                          std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
     struct sockaddr_in serv_addr;
@@ -1512,7 +1498,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1541,7 +1527,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1573,7 +1559,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         // std::cout << response << std::endl;
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1585,14 +1571,14 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
             }
 
             server_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1607,7 +1593,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_LEN) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_LEN, "info");
@@ -1621,7 +1607,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                     bzero(data, FED_DATA_LENGTH + 1);
                     read(sockfd, data, FED_DATA_LENGTH);
                     response = (data);
-                    // response = utils.trim_copy(response, " \f\n\r\t\v");
+                    // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_CONT) == 0) {
                         server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_CONT, "info");
@@ -1645,7 +1631,7 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                // response = utils.trim_copy(response, " \f\n\r\t\v");
+                // response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::FILE_RECV_WAIT) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::FILE_RECV_WAIT, "info");
@@ -1695,7 +1681,6 @@ bool JasmineGraphServer::batchUploadCentralAttributeFile(std::string host, int p
 
 bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, int port, int dataPort, int graphID,
                                                               std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
     struct sockaddr_in serv_addr;
@@ -1709,7 +1694,7 @@ bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, 
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -1738,7 +1723,7 @@ bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, 
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -1770,7 +1755,7 @@ bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, 
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -1782,14 +1767,14 @@ bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, 
             }
 
             server_logger.log("Sent : Graph ID " + std::to_string(graphID), "info");
-            std::string fileName = utils.getFileName(filePath);
-            int fileSize = utils.getFileSize(filePath);
+            std::string fileName = Utils::getFileName(filePath);
+            int fileSize = Utils::getFileSize(filePath);
             std::string fileLength = to_string(fileSize);
 
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE_NAME) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_FILE_NAME, "info");
@@ -1889,7 +1874,6 @@ bool JasmineGraphServer::batchUploadCompositeCentralstoreFile(std::string host, 
 
 bool JasmineGraphServer::sendFileThroughService(std::string host, int dataPort, std::string fileName,
                                                 std::string filePath, std::string masterIP) {
-    Utils utils;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
     socklen_t len;
@@ -1926,7 +1910,7 @@ bool JasmineGraphServer::sendFileThroughService(std::string host, int dataPort, 
     bzero(data, FED_DATA_LENGTH + 1);
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::SEND_FILE) == 0) {
         std::cout << "Sending file " << filePath << " through port " << dataPort << std::endl;
@@ -2115,13 +2099,12 @@ void JasmineGraphServer::createLogFilePath(std::string workerHost, std::string w
 
 void JasmineGraphServer::addHostsToMetaDB(std::string host, std::vector<int> portVector,
                                           std::vector<int> dataPortVector) {
-    Utils utils;
     string name = host;
     string sqlStatement = "";
     string ip_address = "";
     string user = "";
     if (host.find('@') != std::string::npos) {
-        vector<string> splitted = utils.split(host, '@');
+        vector<string> splitted = Utils::split(host, '@');
         ip_address = splitted[1];
         user = splitted[0];
     } else {
@@ -2132,7 +2115,7 @@ void JasmineGraphServer::addHostsToMetaDB(std::string host, std::vector<int> por
         int workerPort = portVector.at(i);
         int workerDataPort = dataPortVector.at(i);
 
-        if (!utils.hostExists(name, ip_address, std::to_string(workerPort), this->sqlite)) {
+        if (!Utils::hostExists(name, ip_address, std::to_string(workerPort), this->sqlite)) {
             string hostID = Utils::getHostID(name, this->sqlite);
             sqlStatement =
                 ("INSERT INTO worker (host_idhost,name,ip,user,is_public,server_port,server_data_port) VALUES (\"" +
@@ -2205,7 +2188,6 @@ void JasmineGraphServer::removeGraph(vector<pair<string, string>> hostHasPartiti
  *  @param masterIP IP of master node
  */
 int JasmineGraphServer::removeFragmentThroughService(string host, int port, string graphID, string masterIP) {
-    Utils utils;
     std::cout << pthread_self() << " host : " << host << " port : " << port << std::endl;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -2222,7 +2204,7 @@ int JasmineGraphServer::removeFragmentThroughService(string host, int port, stri
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -2252,7 +2234,7 @@ int JasmineGraphServer::removeFragmentThroughService(string host, int port, stri
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -2284,7 +2266,7 @@ int JasmineGraphServer::removeFragmentThroughService(string host, int port, stri
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
             result_wr = write(sockfd, graphID.c_str(), graphID.size());
@@ -2298,7 +2280,7 @@ int JasmineGraphServer::removeFragmentThroughService(string host, int port, stri
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
             server_logger.log("Received last response : " + response, "info");
             return 1;
 
@@ -2313,7 +2295,6 @@ int JasmineGraphServer::removeFragmentThroughService(string host, int port, stri
 
 int JasmineGraphServer::removePartitionThroughService(string host, int port, string graphID, string partitionID,
                                                       string masterIP) {
-    Utils utils;
     std::cout << pthread_self() << " host : " << host << " port : " << port << std::endl;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -2330,7 +2311,7 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -2360,7 +2341,7 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
@@ -2392,7 +2373,7 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2407,7 +2388,7 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::SEND_PARTITION_ID) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::SEND_PARTITION_ID, "info");
@@ -2422,7 +2403,7 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
                 server_logger.log("Received last response : " + response, "info");
                 return 1;
             } else {
@@ -2441,13 +2422,12 @@ int JasmineGraphServer::removePartitionThroughService(string host, int port, str
 std::vector<JasmineGraphServer::workers> JasmineGraphServer::getHostWorkerMap() { return hostWorkerMap; }
 
 void JasmineGraphServer::updateOperationalGraphList() {
-    Utils utils;
     string hosts = "";
     string graphIDs = "";
     std::vector<std::string> hostsList;
 
     if (profile == "native") {
-        hostsList = utils.getHostListFromProperties();
+        hostsList = Utils::getHostListFromProperties();
     } else if (profile == "docker") {
         hostsList = getWorkerVector(workerHosts);
     }
@@ -2565,14 +2545,12 @@ bool JasmineGraphServer::hasEnding(std::string const &fullString, std::string co
 }
 
 std::vector<std::string> JasmineGraphServer::getWorkerVector(std::string workerList) {
-    Utils utils;
-    std::vector<std::string> workerVector = utils.split(workerList, ',');
+    std::vector<std::string> workerVector = Utils::split(workerList, ',');
     return workerVector;
 }
 
 void JasmineGraphServer::backupPerformanceDB() {
-    Utils utils;
-    std::string performanceDBPath = utils.getJasmineGraphProperty("org.jasminegraph.performance.db.location");
+    std::string performanceDBPath = Utils::getJasmineGraphProperty("org.jasminegraph.performance.db.location");
 
     uint64_t currentTimestamp =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
@@ -2615,10 +2593,9 @@ void JasmineGraphServer::addInstanceDetailsToPerformanceDB(std::string host, std
     std::string user;
     std::string ipAddress;
     int count = 0;
-    Utils utils;
 
     if (host.find('@') != std::string::npos) {
-        vector<string> splitted = utils.split(host, '@');
+        vector<string> splitted = Utils::split(host, '@');
         ipAddress = splitted[1];
         user = splitted[0];
     } else {
@@ -2684,7 +2661,6 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
     string host;
     int port;
     std::string workerList;
-    Utils utils;
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator workerit;
     for (workerit = graphPartitionedHosts.begin(); workerit != graphPartitionedHosts.end(); workerit++) {
         JasmineGraphServer::workerPartition workerPartition = workerit->second;
@@ -2693,7 +2669,7 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
         port = workerPartition.port;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         workerList.append(host + ":" + std::to_string(port) + ":" + partition + ",");
@@ -2708,7 +2684,7 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
         port = workerPartition.port;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         int sockfd;
@@ -2748,7 +2724,7 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         string response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2763,7 +2739,7 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             string response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2779,7 +2755,7 @@ void JasmineGraphServer::inDegreeDistribution(std::string graphID) {
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2804,7 +2780,6 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
     string host;
     int port;
     std::string workerList;
-    Utils utils;
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator workerit;
     for (workerit = graphPartitionedHosts.begin(); workerit != graphPartitionedHosts.end(); workerit++) {
         JasmineGraphServer::workerPartition workerPartition = workerit->second;
@@ -2813,7 +2788,7 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
         port = workerPartition.port;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         workerList.append(host + ":" + std::to_string(port) + ":" + partition + ",");
@@ -2828,7 +2803,7 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
         port = workerPartition.port;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
         int sockfd;
         char data[FED_DATA_LENGTH + 1];
@@ -2867,7 +2842,7 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         string response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2882,7 +2857,7 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
             bzero(data, FED_DATA_LENGTH + 1);
             read(sockfd, data, FED_DATA_LENGTH);
             string response = (data);
-            response = utils.trim_copy(response, " \f\n\r\t\v");
+            response = Utils::trim_copy(response, " \f\n\r\t\v");
 
             if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                 server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2897,7 +2872,7 @@ void JasmineGraphServer::outDegreeDistribution(std::string graphID) {
                 bzero(data, FED_DATA_LENGTH + 1);
                 read(sockfd, data, FED_DATA_LENGTH);
                 string response = (data);
-                response = utils.trim_copy(response, " \f\n\r\t\v");
+                response = Utils::trim_copy(response, " \f\n\r\t\v");
 
                 if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
                     server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -2932,7 +2907,6 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
     int port;
     int dport;
     std::string workerList;
-    Utils utils;
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator workerit;
     for (workerit = graphPartitionedHosts.begin(); workerit != graphPartitionedHosts.end(); workerit++) {
         JasmineGraphServer::workerPartition workerPartition = workerit->second;
@@ -2942,7 +2916,7 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
         dport = workerPartition.dataPort;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         workerList.append(host + ":" + std::to_string(port) + ":" + partition + ":" + to_string(dport) + ",");
@@ -2956,7 +2930,7 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
         port = workerPartition.port;
 
         if (host.find('@') != std::string::npos) {
-            host = utils.split(host, '@')[1];
+            host = Utils::split(host, '@')[1];
         }
 
         int sockfd;
@@ -2996,7 +2970,7 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         string response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3014,7 +2988,7 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3035,7 +3009,7 @@ void JasmineGraphServer::duplicateCentralStore(std::string graphID) {
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
@@ -3079,9 +3053,8 @@ void JasmineGraphServer::initiateFiles(std::string graphID, std::string training
 
     std::thread workerThreads[partition_count + 1];
 
-    Utils utils;
-    string prefix = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder");
-    string attr_prefix = utils.getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
+    string prefix = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.trainedmodelfolder");
+    string attr_prefix = Utils::getJasmineGraphProperty("org.jasminegraph.server.instance.datafolder");
     trainingArgs = trainingArgs;
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator j;
     for (j = graphPartitionedHosts.begin(); j != graphPartitionedHosts.end(); j++) {
@@ -3109,13 +3082,12 @@ void JasmineGraphServer::initiateFiles(std::string graphID, std::string training
 
 void JasmineGraphServer::initiateCommunication(std::string graphID, std::string trainingArgs,
                                                SQLiteDBInterface sqlite) {
-    Utils utils;
-    int fl_clients = stoi(utils.getJasmineGraphProperty("org.jasminegraph.fl_clients"));
+    int fl_clients = stoi(Utils::getJasmineGraphProperty("org.jasminegraph.fl_clients"));
     int threadLimit = fl_clients + 1;
     std::thread *workerThreads = new std::thread[threadLimit];
 
     Utils::worker workerInstance;
-    vector<Utils::worker> workerVector = utils.getWorkerList(sqlite);
+    vector<Utils::worker> workerVector = Utils::getWorkerList(sqlite);
 
     trainingArgs = trainingArgs;
     int threadID = 0;
@@ -3148,34 +3120,33 @@ void JasmineGraphServer::initiateCommunication(std::string graphID, std::string 
 
 void JasmineGraphServer::initiateOrgCommunication(std::string graphID, std::string trainingArgs,
                                                   SQLiteDBInterface sqlite) {
-    Utils utils;
-    int fl_clients = stoi(utils.getJasmineGraphProperty("org.jasminegraph.fl_clients"));
-    int orgs_count = stoi(utils.getJasmineGraphProperty("org.jasminegraph.fl.num.orgs"));
-    std::string flagPath = utils.getJasmineGraphProperty("org.jasminegraph.fl.flag.file");
+    int fl_clients = stoi(Utils::getJasmineGraphProperty("org.jasminegraph.fl_clients"));
+    int orgs_count = stoi(Utils::getJasmineGraphProperty("org.jasminegraph.fl.num.orgs"));
+    std::string flagPath = Utils::getJasmineGraphProperty("org.jasminegraph.fl.flag.file");
     int threadLimit = fl_clients + 1;
     int org_thread_count = 0;
     std::thread *workerThreads = new std::thread[threadLimit];
 
-    utils.editFlagOne(flagPath);
+    Utils::editFlagOne(flagPath);
     Utils::worker workerInstance;
-    vector<Utils::worker> workerVector = utils.getWorkerList(sqlite);
+    vector<Utils::worker> workerVector = Utils::getWorkerList(sqlite);
 
     std::thread *trainThreads = new std::thread[orgs_count];
 
-    if (utils.getJasmineGraphProperty("org.jasminegraph.fl.aggregator") == "true") {
+    if (Utils::getJasmineGraphProperty("org.jasminegraph.fl.aggregator") == "true") {
         std::thread *orgAggThread = new std::thread[1];
         orgAggThread[0] = std::thread(initiateAggregator, "localhost", stoi(workerVector[0].port),
                                       stoi(workerVector[0].dataPort), trainingArgs, fl_clients, "1");
         orgAggThread[0].join();
     }
 
-    std::ifstream file(utils.getJasmineGraphProperty("org.jasminegraph.fl.organization.file"));
+    std::ifstream file(Utils::getJasmineGraphProperty("org.jasminegraph.fl.organization.file"));
 
     if (file.good()) {
         if (file.is_open()) {
             std::string line;
             while (std::getline(file, line)) {
-                line = utils.trim_copy(line, " \f\n\r\t\v");
+                line = Utils::trim_copy(line, " \f\n\r\t\v");
                 std::vector<std::string> strArr = Utils::split(line.c_str(), '|');
                 std::string host = strArr[0].c_str();
                 int port = stoi(strArr[1].c_str());
@@ -3245,9 +3216,8 @@ void JasmineGraphServer::initiateMerge(std::string graphID, std::string training
 
     std::thread *workerThreads = new std::thread[partition_count + 1];
 
-    Utils utils;
     trainingArgs = trainingArgs;
-    int fl_clients = stoi(utils.getJasmineGraphProperty("org.jasminegraph.fl_clients"));
+    int fl_clients = stoi(Utils::getJasmineGraphProperty("org.jasminegraph.fl_clients"));
     std::map<std::string, JasmineGraphServer::workerPartition>::iterator j;
     for (j = graphPartitionedHosts.begin(); j != graphPartitionedHosts.end(); j++) {
         JasmineGraphServer::workerPartition workerPartition = j->second;
@@ -3273,7 +3243,6 @@ void JasmineGraphServer::initiateMerge(std::string graphID, std::string training
 
 bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort, std::string trainingArgs,
                                        int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -3290,7 +3259,7 @@ bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort,
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3319,11 +3288,11 @@ bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort,
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         result_wr = write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent : " + server_host, "info");
         if (result_wr < 0) {
@@ -3333,7 +3302,7 @@ bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort,
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -3347,7 +3316,7 @@ bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort,
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
@@ -3366,7 +3335,6 @@ bool JasmineGraphServer::initiateTrain(std::string host, int port, int dataPort,
 
 bool JasmineGraphServer::initiatePredict(std::string host, int port, int dataPort, std::string trainingArgs,
                                          int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH];
@@ -3383,7 +3351,7 @@ bool JasmineGraphServer::initiatePredict(std::string host, int port, int dataPor
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3407,11 +3375,11 @@ bool JasmineGraphServer::initiatePredict(std::string host, int port, int dataPor
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent : " + server_host, "info");
 
@@ -3421,7 +3389,7 @@ bool JasmineGraphServer::initiatePredict(std::string host, int port, int dataPor
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::OK, "info");
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
@@ -3440,7 +3408,6 @@ bool JasmineGraphServer::initiatePredict(std::string host, int port, int dataPor
 
 bool JasmineGraphServer::initiateServer(std::string host, int port, int dataPort, std::string trainingArgs,
                                         int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -3457,7 +3424,7 @@ bool JasmineGraphServer::initiateServer(std::string host, int port, int dataPort
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3481,17 +3448,17 @@ bool JasmineGraphServer::initiateServer(std::string host, int port, int dataPort
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received fed : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent fed : " + server_host, "info");
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -3503,7 +3470,7 @@ bool JasmineGraphServer::initiateServer(std::string host, int port, int dataPort
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received fed : " + JasmineGraphInstanceProtocol::OK, "info");
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
@@ -3523,7 +3490,6 @@ bool JasmineGraphServer::initiateServer(std::string host, int port, int dataPort
 // todo Remove partCount from parameters as the partition id is being parsed within the training args
 bool JasmineGraphServer::initiateClient(std::string host, int port, int dataPort, std::string trainingArgs,
                                         int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -3540,7 +3506,7 @@ bool JasmineGraphServer::initiateClient(std::string host, int port, int dataPort
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3564,17 +3530,17 @@ bool JasmineGraphServer::initiateClient(std::string host, int port, int dataPort
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received fed : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent fed : " + server_host, "info");
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -3586,7 +3552,7 @@ bool JasmineGraphServer::initiateClient(std::string host, int port, int dataPort
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log(to_string(pthread_self()) + " Received fed : " + JasmineGraphInstanceProtocol::OK,
                               "info");
@@ -3606,7 +3572,6 @@ bool JasmineGraphServer::initiateClient(std::string host, int port, int dataPort
 
 bool JasmineGraphServer::initiateAggregator(std::string host, int port, int dataPort, std::string trainingArgs,
                                             int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -3623,7 +3588,7 @@ bool JasmineGraphServer::initiateAggregator(std::string host, int port, int data
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3647,11 +3612,11 @@ bool JasmineGraphServer::initiateAggregator(std::string host, int port, int data
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent host : " + server_host, "info");
 
@@ -3670,7 +3635,7 @@ bool JasmineGraphServer::initiateAggregator(std::string host, int port, int data
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
             bzero(data, FED_DATA_LENGTH);
@@ -3687,7 +3652,6 @@ bool JasmineGraphServer::initiateAggregator(std::string host, int port, int data
 
 bool JasmineGraphServer::initiateOrgServer(std::string host, int port, int dataPort, std::string trainingArgs,
                                            int iteration, string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH];
@@ -3704,7 +3668,7 @@ bool JasmineGraphServer::initiateOrgServer(std::string host, int port, int dataP
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3728,11 +3692,11 @@ bool JasmineGraphServer::initiateOrgServer(std::string host, int port, int dataP
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received fed : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent fed : " + server_host, "info");
 
@@ -3742,7 +3706,7 @@ bool JasmineGraphServer::initiateOrgServer(std::string host, int port, int dataP
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received fed : " + JasmineGraphInstanceProtocol::OK, "info");
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
@@ -3762,7 +3726,6 @@ bool JasmineGraphServer::initiateOrgServer(std::string host, int port, int dataP
 bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::string trainingArgs, int iteration,
                                               std::string partCount) {
     int HEADER_LENGTH = 10;
-    Utils utils;
     bool result = true;
     int sockfd;
 
@@ -3771,8 +3734,8 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
     struct sockaddr_in serv_addr;
     struct hostent *server;
 
-    std::string weights_file = utils.getJasmineGraphProperty("org.jasminegraph.fl.weights.file");
-    std::string flagPath = utils.getJasmineGraphProperty("org.jasminegraph.fl.flag.file");
+    std::string weights_file = Utils::getJasmineGraphProperty("org.jasminegraph.fl.weights.file");
+    std::string flagPath = Utils::getJasmineGraphProperty("org.jasminegraph.fl.flag.file");
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -3781,7 +3744,7 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
         return 0;
     }
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
     server = gethostbyname(host.c_str());
     if (server == NULL) {
@@ -3823,7 +3786,7 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
         ofstream stream;
         std::ofstream file(weights_file, std::ios::out);
         file.write(content, full_size);
-        utils.editFlagZero(flagPath);
+        Utils::editFlagZero(flagPath);
         server_logger.log("Done writting to the weight file", "info");
         std::string path = weights_file + to_string(count) + ".txt";
         count++;
@@ -3832,7 +3795,7 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
 
         while (true) {
             sleep(DELAY);
-            if (utils.checkFlag(flagPath) == "1") {
+            if (Utils::checkFlag(flagPath) == "1") {
                 ifstream infile{weights_file};
                 server_logger.log("Weight file opened", "info");
                 string file_contents{istreambuf_iterator<char>(infile), istreambuf_iterator<char>()};
@@ -3841,7 +3804,7 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
                 server_logger.log("Writing to the socket", "info");
                 break;
 
-            } else if (utils.checkFlag(flagPath) == "STOP") {
+            } else if (Utils::checkFlag(flagPath) == "STOP") {
                 isTrue = true;
                 break;
             }
@@ -3859,7 +3822,6 @@ bool JasmineGraphServer::receiveGlobalWeights(std::string host, int port, std::s
 
 bool JasmineGraphServer::mergeFiles(std::string host, int port, int dataPort, std::string trainingArgs, int iteration,
                                     string partCount) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH + 1];
@@ -3876,7 +3838,7 @@ bool JasmineGraphServer::mergeFiles(std::string host, int port, int dataPort, st
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());
@@ -3900,18 +3862,18 @@ bool JasmineGraphServer::mergeFiles(std::string host, int port, int dataPort, st
     read(sockfd, data, FED_DATA_LENGTH);
     string response = (data);
 
-    response = utils.trim_copy(response, " \f\n\r\t\v");
+    response = Utils::trim_copy(response, " \f\n\r\t\v");
 
     if (response.compare(JasmineGraphInstanceProtocol::HANDSHAKE_OK) == 0) {
         server_logger.log("Received merge : " + JasmineGraphInstanceProtocol::HANDSHAKE_OK, "info");
-        string server_host = utils.getJasmineGraphProperty("org.jasminegraph.server.host");
+        string server_host = Utils::getJasmineGraphProperty("org.jasminegraph.server.host");
         write(sockfd, server_host.c_str(), server_host.size());
         server_logger.log("Sent merge : " + server_host, "info");
 
         bzero(data, FED_DATA_LENGTH + 1);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
 
         if (response.compare(JasmineGraphInstanceProtocol::HOST_OK) == 0) {
             server_logger.log("Received : " + JasmineGraphInstanceProtocol::HOST_OK, "info");
@@ -3923,7 +3885,7 @@ bool JasmineGraphServer::mergeFiles(std::string host, int port, int dataPort, st
         bzero(data, FED_DATA_LENGTH);
         read(sockfd, data, FED_DATA_LENGTH);
         response = (data);
-        response = utils.trim_copy(response, " \f\n\r\t\v");
+        response = Utils::trim_copy(response, " \f\n\r\t\v");
         if (response.compare(JasmineGraphInstanceProtocol::OK) == 0) {
             server_logger.log("Received merge : " + JasmineGraphInstanceProtocol::OK, "info");
             write(sockfd, (trainingArgs).c_str(), (trainingArgs).size());
@@ -3941,7 +3903,6 @@ bool JasmineGraphServer::mergeFiles(std::string host, int port, int dataPort, st
 }
 
 bool JasmineGraphServer::sendTrainCommand(std::string host, int port, std::string trainingArgs) {
-    Utils utils;
     bool result = true;
     int sockfd;
     char data[FED_DATA_LENGTH];
@@ -3958,7 +3919,7 @@ bool JasmineGraphServer::sendTrainCommand(std::string host, int port, std::strin
     }
 
     if (host.find('@') != std::string::npos) {
-        host = utils.split(host, '@')[1];
+        host = Utils::split(host, '@')[1];
     }
 
     server = gethostbyname(host.c_str());

--- a/src/util/PlacesToNodeMapper.cpp
+++ b/src/util/PlacesToNodeMapper.cpp
@@ -19,22 +19,20 @@ using namespace std;
 Logger node_logger;
 
 std::string PlacesToNodeMapper::getHost(long placeId) {
-    Utils utils;
-    std::vector<std::string> hostList = utils.getHostListFromProperties();
+    std::vector<std::string> hostList = Utils::getHostListFromProperties();
     std::string& host = hostList.at(placeId);
     return host;
 }
 
 std::vector<int> PlacesToNodeMapper::getInstancePortsList(long placeId) {
-    Utils utils;
     int numberOfWorkersPerHost;
     int numberOfWorkers = 0;
     int hostListModeNWorkers;
     std::vector<int> portList;
-    std::vector<std::string> hostList = utils.getHostListFromProperties();
-    std::string nWorkers = utils.getJasmineGraphProperty("org.jasminegraph.server.nworkers");
+    std::vector<std::string> hostList = Utils::getHostListFromProperties();
+    std::string nWorkers = Utils::getJasmineGraphProperty("org.jasminegraph.server.nworkers");
     int workerPort = Conts::JASMINEGRAPH_INSTANCE_PORT;
-    if (utils.is_number(nWorkers)) {
+    if (Utils::is_number(nWorkers)) {
         numberOfWorkers = atoi(nWorkers.c_str());
     } else {
         node_logger.log("Number of Workers specified in the properties is not an integer value.", "error");
@@ -66,16 +64,15 @@ std::vector<int> PlacesToNodeMapper::getInstancePortsList(long placeId) {
 }
 
 std::vector<int> PlacesToNodeMapper::getFileTransferServicePort(long placeId) {
-    Utils utils;
     int numberOfWorkersPerHost;
     int numberOfWorkers = 0;
     int hostListModeNWorkers;
     std::vector<int> portList;
-    std::vector<std::string> hostList = utils.getHostListFromProperties();
-    std::string nWorkers = utils.getJasmineGraphProperty("org.jasminegraph.server.nworkers");
+    std::vector<std::string> hostList = Utils::getHostListFromProperties();
+    std::string nWorkers = Utils::getJasmineGraphProperty("org.jasminegraph.server.nworkers");
     int workerPort = Conts::JASMINEGRAPH_INSTANCE_PORT;
     int workerDataPort = Conts::JASMINEGRAPH_INSTANCE_DATA_PORT;
-    if (utils.is_number(nWorkers)) {
+    if (Utils::is_number(nWorkers)) {
         numberOfWorkers = atoi(nWorkers.c_str());
     } else {
         node_logger.log("Number of Workers is not specified", "error");

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -32,34 +32,6 @@ Logger util_logger;
 
 unordered_map<std::string, std::string> Utils::propertiesMap;
 
-map<std::string, std::string> Utils::getBatchUploadFileList(std::string file) {
-    std::vector<std::string> batchUploadFileContent = getFileContent(file);
-    std::vector<std::string>::iterator iterator1 = batchUploadFileContent.begin();
-    map<std::string, std::string> *result = new map<std::string, std::string>();
-    while (iterator1 != batchUploadFileContent.end()) {
-        std::string str = *iterator1;
-
-        if (str.length() > 0 && !(str.rfind("#", 0) == 0)) {
-            std::vector<std::string> vec = split(str, ':');
-
-            //            ifstream batchUploadConfFile(vec.at(1));
-            //            string line;
-            //
-            //            if (batchUploadConfFile.is_open()) {
-            //                while (getline(batchUploadConfFile, line)) {
-            //                    cout << line << '\n';
-            //                }
-            //            }
-
-            result->insert(std::pair<std::string, std::string>(vec.at(0), vec.at(1)));
-        }
-
-        iterator1++;
-    }
-
-    return *result;
-}
-
 std::vector<std::string> Utils::split(const std::string &s, char delimiter) {
     std::vector<std::string> tokens;
     std::string token;
@@ -89,7 +61,7 @@ std::vector<std::string> Utils::getFileContent(std::string file) {
 std::string Utils::getJasmineGraphProperty(std::string key) {
     if (Utils::propertiesMap.empty()) {
         std::vector<std::string>::iterator it;
-        vector<std::string> vec = getFileContent("conf/jasminegraph-server.properties");
+        vector<std::string> vec = Utils::getFileContent("conf/jasminegraph-server.properties");
         it = vec.begin();
 
         for (it = vec.begin(); it < vec.end(); it++) {
@@ -112,7 +84,7 @@ std::string Utils::getJasmineGraphProperty(std::string key) {
 }
 
 std::vector<Utils::worker> Utils::getWorkerList(SQLiteDBInterface sqlite) {
-    vector<worker> workerVector;
+    vector<Utils::worker> workerVector;
     std::vector<vector<pair<string, string>>> v =
         sqlite.runSelect("SELECT idworker,user,ip,server_port,server_data_port FROM worker;");
     for (int i = 0; i < v.size(); i++) {
@@ -138,7 +110,7 @@ std::vector<Utils::worker> Utils::getWorkerList(SQLiteDBInterface sqlite) {
 std::vector<std::string> Utils::getHostListFromProperties() {
     std::vector<std::string> result;
     std::vector<std::string>::iterator it;
-    vector<std::string> vec = getFileContent("conf/hosts.txt");
+    vector<std::string> vec = Utils::getFileContent("conf/hosts.txt");
     it = vec.begin();
 
     for (it = vec.begin(); it < vec.end(); it++) {
@@ -151,11 +123,11 @@ std::vector<std::string> Utils::getHostListFromProperties() {
     return result;
 }
 
-inline std::string trim_right_copy(const std::string &s, const std::string &delimiters = " \f\n\r\t\v") {
+static inline std::string trim_right_copy(const std::string &s, const std::string &delimiters = " \f\n\r\t\v") {
     return s.substr(0, s.find_last_not_of(delimiters) + 1);
 }
 
-inline std::string trim_left_copy(const std::string &s, const std::string &delimiters = " \f\n\r\t\v") {
+static inline std::string trim_left_copy(const std::string &s, const std::string &delimiters = " \f\n\r\t\v") {
     return s.substr(s.find_first_not_of(delimiters));
 }
 
@@ -180,21 +152,16 @@ bool Utils::parseBoolean(const std::string str) {
  * @param fileName
  * @return
  */
-bool Utils::fileExists(std::string fileName) {
-    std::ifstream infile(fileName);
-    return infile.good();
-}
+bool Utils::fileExists(std::string fileName) { return access(fileName.c_str(), F_OK) == 0; }
 
 /**
  * This method creates a new directory if it does not exist
  * @param dirName
  */
 void Utils::createDirectory(const std::string dirName) {
-    if (mkdir(dirName.c_str(), 0777) == -1) {
-        // std::cout << "Error : " << strerror(errno) << endl;
-    } else {
-        // util_logger.log("Directory " + dirName + " created successfully", "info");
-    }
+    // TODO: check if directory exists before creating
+    // TODO: check return value
+    mkdir(dirName.c_str(), 0777);
 }
 
 std::vector<std::string> Utils::getListOfFilesInDirectory(const std::string dirName) {
@@ -239,10 +206,14 @@ std::vector<std::string> Utils::getListOfFilesInDirectory(const std::string dirN
  */
 // TODO :: find a possible solution to handle the permission denied error when trying to delete a protected directory.
 // popen does not work either
-void Utils::deleteDirectory(const std::string dirName) {
+int Utils::deleteDirectory(const std::string dirName) {
     string command = "rm -rf " + dirName;
-    system(command.c_str());
-    util_logger.log(dirName + " deleted successfully", "info");
+    int status = system(command.c_str());
+    if (status == 0)
+        util_logger.info(dirName + " deleted successfully");
+    else
+        util_logger.warn("Deleting " + dirName + " failed with exit code " + std::to_string(status));
+    return status;
 }
 
 bool Utils::is_number(const std::string &compareString) {
@@ -256,6 +227,7 @@ bool Utils::is_number(const std::string &compareString) {
  * @return
  */
 std::string Utils::getFileName(std::string filePath) {
+    // FIXME: Can file path separator be '\' on Linux?
     std::string filename = filePath.substr(filePath.find_last_of("/\\") + 1);
     return filename;
 }
@@ -290,11 +262,12 @@ std::string Utils::getHomeDir() {
  * This method copies the file
  * @param filePath
  */
-void Utils::copyFile(const std::string sourceFilePath, const std::string destinationFilePath) {
+int Utils::copyFile(const std::string sourceFilePath, const std::string destinationFilePath) {
     util_logger.log("Starting file copy source: " + sourceFilePath + " destination: " + destinationFilePath, "info");
     std::string command = "cp " + sourceFilePath + " " + destinationFilePath;
-    FILE *copyInput = popen(command.c_str(), "r");
-    pclose(copyInput);
+    int status = system(command.c_str());
+    if (status != 0) util_logger.warn("Copy failed with exit code " + std::to_string(status));
+    return status;
 }
 
 /**
@@ -319,72 +292,38 @@ int Utils::getFileSize(std::string filePath) {
  * This method compresses files using gzip
  * @param filePath
  */
-void Utils::compressFile(const std::string filePath, const std::string mode) {
-    char buffer[128];
-    std::string result = "";
-    std::string command = mode + " -f " + filePath + " 2>&1";
-    char *commandChar = new char[command.length() + 1];
-    strcpy(commandChar, command.c_str());
-    FILE *input = popen(commandChar, "r");
-    if (input) {
-        while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
-                result.append(buffer);
-            }
+int Utils::compressFile(const std::string filePath, std::string mode) {
+    if (mode == "pigz") {
+        if (access("/usr/bin/pigz", X_OK) != 0) {
+            util_logger.info("pigz not found. Compressing using gzip");
+            mode = "gzip";
         }
-        pclose(input);
-        if (!result.empty()) {
-            if (result.find("pigz: not found") != std::string::npos) {
-                util_logger.log("pigz not found. Compressing using gzip", "info");
-                compressFile(filePath, "gzip");
-            } else {
-                util_logger.log("File compression failed with error: " + result, "error");
-            }
-        }
-    } else {
-        perror("popen");
-        // handle error
     }
+    std::string command = mode + " -f " + filePath + " 2>&1";
+    int status = system(command.c_str());
+    if (status!=0) {
+        util_logger.error("File compression failed with code " + std::to_string(status));
+    }
+    return status;
 }
 
 /**
  * this method extracts a gzip file
  * @param filePath
  */
-void Utils::unzipFile(std::string filePath, const std::string mode) {
-    char buffer[128];
-    std::string result = "";
+int Utils::unzipFile(std::string filePath, std::string mode) {
+    if (mode == "pigz") {
+        if (access("/usr/bin/pigz", X_OK) != 0) {
+            util_logger.info("pigz not found. Compressing using gzip");
+            mode = "gzip";
+        }
+    }
     std::string command = mode + " -f -d " + filePath + " 2>&1";
-    char *commandChar = new char[command.length() + 1];
-    strcpy(commandChar, command.c_str());
-    FILE *input = popen(commandChar, "r");
-    if (input) {
-        while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
-                result.append(buffer);
-            }
-        }
-        pclose(input);
-        if (!result.empty()) {
-            if (result.find("pigz: not found") != std::string::npos) {
-                util_logger.log("pigz not found. Decompressing using gzip", "info");
-                unzipFile(filePath, "gzip");
-            } else {
-                util_logger.log("File decompression failed with error: " + result, "error");
-            }
-        }
-    } else {
-        perror("popen");
-        // handle error
+    int status = system(command.c_str());
+    if (status!=0) {
+        util_logger.error("File decompression failed with code " + std::to_string(status));
     }
-}
-
-int Utils::parseARGS(char **args, char *line) {
-    int tmp = 0;
-    args[tmp] = strtok(line, ":");
-    while ((args[++tmp] = strtok(NULL, ":")) != NULL) {
-    }
-    return tmp - 1;
+    return status;
 }
 
 /**
@@ -419,58 +358,26 @@ string Utils::getHostID(string hostName, SQLiteDBInterface sqlite) {
  * This method compresses directories using tar
  * @param filePath
  */
-void Utils::compressDirectory(const std::string filePath) {
-    char buffer[128];
-    std::string result = "";
-    std::string command = "tar -czvf " + filePath + ".tar.gz " + filePath;
-    char *commandChar = new char[command.length() + 1];
-    strcpy(commandChar, command.c_str());
-    FILE *input = popen(commandChar, "r");
-    if (input) {
-        while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
-                result.append(buffer);
-            }
-        }
-        pclose(input);
-        if (!result.empty()) {
-            util_logger.log("Directory compression failed with error: " + result, "error");
-        } else {
-            // util_logger.log("File in " + filePath + " compressed with gzip", "info");
-        }
-    } else {
-        perror("popen");
-        // handle error
+int Utils::compressDirectory(const std::string filePath) {
+    std::string command = "tar -czf " + filePath + ".tar.gz " + filePath;
+    int status = system(command.c_str());
+    if (status!=0) {
+        util_logger.error("Directory compression failed with code " + std::to_string(status));
     }
+    return status;
 }
 
 /**
  * this method extracts a tar.gz directory
  * @param filePath
  */
-void Utils::unzipDirectory(std::string filePath) {
-    char buffer[128];
-    std::string result = "";
-    std::string command = "tar -xzvf " + filePath;
-    char *commandChar = new char[command.length() + 1];
-    strcpy(commandChar, command.c_str());
-    FILE *input = popen(commandChar, "r");
-    if (input) {
-        while (!feof(input)) {
-            if (fgets(buffer, 128, input) != NULL) {
-                result.append(buffer);
-            }
-        }
-        pclose(input);
-        if (!result.empty()) {
-            util_logger.log("Directory decompression failed with error : " + result, "error");
-        } else {
-            // util_logger.log("File in " + filePath + " extracted with gzip", "info");
-        }
-    } else {
-        perror("popen");
-        // handle error
+int Utils::unzipDirectory(std::string filePath) {
+    std::string command = "tar -xzf " + filePath;
+    int status = system(command.c_str());
+    if (status!=0) {
+        util_logger.error("Directory compression failed with code " + std::to_string(status));
     }
+    return status;
 }
 
 void Utils::assignPartitionsToWorkers(int numberOfWorkers, SQLiteDBInterface sqlite) {
@@ -551,9 +458,13 @@ void Utils::updateSLAInformation(PerformanceSQLiteDBInterface perfSqlite, std::s
     }
 }
 
-void Utils::copyToDirectory(std::string currentPath, std::string copyPath) {
+int Utils::copyToDirectory(std::string currentPath, std::string copyPath) {
     std::string command = "mkdir -p " + copyPath + "&& " + "cp " + currentPath + " " + copyPath;
-    system(command.c_str());
+    int status = system(command.c_str());
+    if (status!=0) {
+        util_logger.error("copyToDirectory failed with code " + std::to_string(status));
+    }
+    return status;
 }
 
 void Utils::editFlagOne(std::string flagPath) {

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -301,7 +301,7 @@ int Utils::compressFile(const std::string filePath, std::string mode) {
     }
     std::string command = mode + " -f " + filePath + " 2>&1";
     int status = system(command.c_str());
-    if (status!=0) {
+    if (status != 0) {
         util_logger.error("File compression failed with code " + std::to_string(status));
     }
     return status;
@@ -320,7 +320,7 @@ int Utils::unzipFile(std::string filePath, std::string mode) {
     }
     std::string command = mode + " -f -d " + filePath + " 2>&1";
     int status = system(command.c_str());
-    if (status!=0) {
+    if (status != 0) {
         util_logger.error("File decompression failed with code " + std::to_string(status));
     }
     return status;
@@ -361,7 +361,7 @@ string Utils::getHostID(string hostName, SQLiteDBInterface sqlite) {
 int Utils::compressDirectory(const std::string filePath) {
     std::string command = "tar -czf " + filePath + ".tar.gz " + filePath;
     int status = system(command.c_str());
-    if (status!=0) {
+    if (status != 0) {
         util_logger.error("Directory compression failed with code " + std::to_string(status));
     }
     return status;
@@ -374,7 +374,7 @@ int Utils::compressDirectory(const std::string filePath) {
 int Utils::unzipDirectory(std::string filePath) {
     std::string command = "tar -xzf " + filePath;
     int status = system(command.c_str());
-    if (status!=0) {
+    if (status != 0) {
         util_logger.error("Directory compression failed with code " + std::to_string(status));
     }
     return status;
@@ -461,7 +461,7 @@ void Utils::updateSLAInformation(PerformanceSQLiteDBInterface perfSqlite, std::s
 int Utils::copyToDirectory(std::string currentPath, std::string copyPath) {
     std::string command = "mkdir -p " + copyPath + "&& " + "cp " + currentPath + " " + copyPath;
     int status = system(command.c_str());
-    if (status!=0) {
+    if (status != 0) {
         util_logger.error("copyToDirectory failed with code " + std::to_string(status));
     }
     return status;

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -462,7 +462,8 @@ int Utils::copyToDirectory(std::string currentPath, std::string copyPath) {
     std::string command = "mkdir -p " + copyPath + "&& " + "cp " + currentPath + " " + copyPath;
     int status = system(command.c_str());
     if (status != 0) {
-        util_logger.error("Copying " + currentPath + " to directory " + copyPath + " failed with code " + std::to_string(status));
+        util_logger.error("Copying " + currentPath + " to directory " + copyPath + " failed with code " +
+                          std::to_string(status));
     }
     return status;
 }

--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -462,7 +462,7 @@ int Utils::copyToDirectory(std::string currentPath, std::string copyPath) {
     std::string command = "mkdir -p " + copyPath + "&& " + "cp " + currentPath + " " + copyPath;
     int status = system(command.c_str());
     if (status != 0) {
-        util_logger.error("copyToDirectory failed with code " + std::to_string(status));
+        util_logger.error("Copying " + currentPath + " to directory " + copyPath + " failed with code " + std::to_string(status));
     }
     return status;
 }

--- a/src/util/Utils.h
+++ b/src/util/Utils.h
@@ -43,54 +43,51 @@ class Utils {
         std::string dataPort;
     };
 
-    map<std::string, std::string> getBatchUploadFileList(std::string file);
+    static std::string getJasmineGraphProperty(std::string key);
 
-    std::string getJasmineGraphProperty(std::string key);
+    static std::vector<worker> getWorkerList(SQLiteDBInterface sqlite);
 
-    std::vector<worker> getWorkerList(SQLiteDBInterface sqlite);
+    static std::vector<std::string> getHostListFromProperties();
 
-    std::vector<std::string> getHostListFromProperties();
-
-    std::vector<std::string> getFileContent(std::string);
+    static std::vector<std::string> getFileContent(std::string);
 
     static std::vector<std::string> split(const std::string &, char delimiter);
 
-    std::string trim_copy(const std::string &, const std::string &);
+    static std::string trim_copy(const std::string &, const std::string &);
 
-    bool parseBoolean(const std::string str);
+    static bool parseBoolean(const std::string str);
 
-    bool fileExists(std::string fileName);
+    static bool fileExists(std::string fileName);
 
-    void compressFile(const std::string filePath, const std::string mode = "pigz");
-    bool is_number(const std::string &compareString);
+    static int compressFile(const std::string filePath, std::string mode = "pigz");
 
-    void createDirectory(const std::string dirName);
+    static bool is_number(const std::string &compareString);
 
-    std::vector<std::string> getListOfFilesInDirectory(const std::string dirName);
+    static void createDirectory(const std::string dirName);
 
-    void deleteDirectory(const std::string dirName);
+    static std::vector<std::string> getListOfFilesInDirectory(const std::string dirName);
 
-    std::string getFileName(std::string filePath);
+    static int deleteDirectory(const std::string dirName);
 
-    int getFileSize(std::string filePath);
+    static std::string getFileName(std::string filePath);
 
-    std::string getJasmineGraphHome();
-    // Static method to get running user's home directory
+    static int getFileSize(std::string filePath);
+
+    static std::string getJasmineGraphHome();
+
     static std::string getHomeDir();
 
-    void copyFile(const std::string sourceFilePath, const std::string destinationFilePath);
+    static int copyFile(const std::string sourceFilePath, const std::string destinationFilePath);
 
-    void unzipFile(std::string filePath, const std::string mode = "pigz");
+    static int unzipFile(std::string filePath, std::string mode = "pigz");
 
-    int parseARGS(char **args, char *line);
+    static bool hostExists(std::string name, std::string ip, std::string workerPort, SQLiteDBInterface sqlite);
 
-    bool hostExists(std::string name, std::string ip, std::string workerPort, SQLiteDBInterface sqlite);
+    static int compressDirectory(const std::string filePath);
 
-    void compressDirectory(const std::string filePath);
+    static int unzipDirectory(std::string filePath);
 
-    void unzipDirectory(std::string filePath);
-
-    void copyToDirectory(std::string currentPath, std::string copyPath);
+    static int copyToDirectory(std::string currentPath, std::string copyPath);
 
     static std::string getHostID(std::string hostName, SQLiteDBInterface sqlite);
 
@@ -99,11 +96,11 @@ class Utils {
     static void updateSLAInformation(PerformanceSQLiteDBInterface perfSqlite, std::string graphId, int partitionCount,
                                      long newSlaValue, std::string command, std::string category);
 
-    void editFlagZero(std::string flagPath);
+    static void editFlagZero(std::string flagPath);
 
-    void editFlagOne(std::string flagPath);
+    static void editFlagOne(std::string flagPath);
 
-    std::string checkFlag(std::string flagPath);
+    static std::string checkFlag(std::string flagPath);
 
     static int connect_wrapper(int sock, const sockaddr *addr, socklen_t slen);
     static std::string getCurrentTimestamp();

--- a/src/util/kafka/KafkaCC.cpp
+++ b/src/util/kafka/KafkaCC.cpp
@@ -20,15 +20,13 @@ void KafkaConnector::Unsubscribe() { consumer.unsubscribe(); }
 GroupInformationList KafkaConnector::Get_consumer_groups() { consumer.get_consumer_groups(); }
 void *KafkaConnector::startStream(string topicName, std::vector<DataPublisher *> workerClients,
                                   std::map<std::string, std::atomic<bool>> *streamsState) {
-    Utils utils;
-
     // After getting the topic name , need to close the connection and ask the user to send the data to given topic
 
-    std::string kafkaHost = utils.getJasmineGraphProperty("org.jasminegraph.server.streaming.kafka.host");
+    std::string kafkaHost = Utils::getJasmineGraphProperty("org.jasminegraph.server.streaming.kafka.host");
     cppkafka::Configuration configs = {{"metadata.broker.list", kafkaHost}, {"group.id", "jasmine"}};
     cppkafka::Consumer consumer(configs);
     // KafkaConnector kstream(configs);
-    std::string partitionCount = utils.getJasmineGraphProperty("org.jasminegraph.server.npartitions");
+    std::string partitionCount = Utils::getJasmineGraphProperty("org.jasminegraph.server.npartitions");
     int numberOfPartitions = std::stoi(partitionCount);
 
     Partitioner graphPartitioner(numberOfPartitions, 0, spt::Algorithms::HASH);

--- a/src/util/scheduler/SchedulerService.cpp
+++ b/src/util/scheduler/SchedulerService.cpp
@@ -20,9 +20,7 @@ using namespace Bosma;
 Logger schedulerservice_logger;
 
 void SchedulerService::startScheduler() {
-    Utils utils;
-
-    std::string schedulerEnabled = utils.getJasmineGraphProperty("org.jasminegraph.scheduler.enabled");
+    std::string schedulerEnabled = Utils::getJasmineGraphProperty("org.jasminegraph.scheduler.enabled");
 
     if (schedulerEnabled == "true") {
         schedulerservice_logger.log("#######SCHEDULER ENABLED#####", "info");
@@ -34,14 +32,13 @@ void SchedulerService::startScheduler() {
 void SchedulerService::startPerformanceScheduler() {
     unsigned int max_n_threads = 12;
 
-    Utils utils;
     PerformanceUtil util;
     util.init();
 
     Bosma::Scheduler scheduler(max_n_threads);
 
     std::string performanceSchedulerTiming =
-        utils.getJasmineGraphProperty("org.jasminegraph.scheduler.performancecollector.timing");
+        Utils::getJasmineGraphProperty("org.jasminegraph.scheduler.performancecollector.timing");
 
     scheduler.every(std::chrono::seconds(atoi(performanceSchedulerTiming.c_str())), util.collectPerformanceStatistics);
 


### PR DESCRIPTION
Convert `Utils` methods to static and remove instantiations of `Utils`.
Fix buffer overflow.