### PR TITLE
Fix instances shutdown issue

### DIFF
--- a/src/server/JasmineGraphInstanceService.h
+++ b/src/server/JasmineGraphInstanceService.h
@@ -47,6 +47,7 @@ limitations under the License.
 #include "JasmineGraphInstanceProtocol.h"
 
 void *instanceservicesession(void *dummyPt);
+void *instanceservicesessionbackground(void *dummyPt);
 void writeCatalogRecord(string record);
 int deleteGraphPartition(std::string graphID, std::string partitionID);
 void removeGraphFragments(std::string graphID);


### PR DESCRIPTION
This fixes the issue of shdn command not properly shutting down the workers. The reason was workers had forked their own instance service sessions which shuts down only the instance service sessions, but not the workers themselves.