### PR TITLE
Fix lint issue of too many args

### DIFF
--- a/src_python/fl_client.py
+++ b/src_python/fl_client.py
@@ -49,6 +49,7 @@ class Client:
     (Without partition sheduling)
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, model, graph_params, weights_path, graph_id, partition_id, epochs=10,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/fl_client.py
+++ b/src_python/fl_client.py
@@ -49,7 +49,7 @@ class Client:
     (Without partition sheduling)
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, model, graph_params, weights_path, graph_id, partition_id, epochs=10,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/fl_client_shed.py
+++ b/src_python/fl_client_shed.py
@@ -53,7 +53,7 @@ class Client:
     on a given GCN model (With partition sheduling)
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, client_id, weights_path, graph_id, partition_ids, epochs=10,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/fl_client_shed.py
+++ b/src_python/fl_client_shed.py
@@ -53,6 +53,7 @@ class Client:
     on a given GCN model (With partition sheduling)
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, client_id, weights_path, graph_id, partition_ids, epochs=10,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/fl_server.py
+++ b/src_python/fl_server.py
@@ -36,6 +36,7 @@ class Server:
     learning process (Without partition sheduling)
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, model, rounds, weights_path, graph_id, max_conn=2, ip=socket.gethostname(),
                  port=5000, header_length=10):
 

--- a/src_python/fl_server.py
+++ b/src_python/fl_server.py
@@ -36,7 +36,7 @@ class Server:
     learning process (Without partition sheduling)
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, model, rounds, weights_path, graph_id, max_conn=2, ip=socket.gethostname(),
                  port=5000, header_length=10):
 

--- a/src_python/fl_server_shed.py
+++ b/src_python/fl_server_shed.py
@@ -35,6 +35,7 @@ class Server:
     learning process (With partition sheduling)
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, model_weights, rounds, weights_path, graph_id, num_clients=2,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/fl_server_shed.py
+++ b/src_python/fl_server_shed.py
@@ -35,7 +35,7 @@ class Server:
     learning process (With partition sheduling)
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, model_weights, rounds, weights_path, graph_id, num_clients=2,
                  ip=socket.gethostname(), port=5000, header_length=10):
 

--- a/src_python/org_agg.py
+++ b/src_python/org_agg.py
@@ -38,7 +38,7 @@ class Aggregator:
     """Aggregator
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, model, rounds, num_orgs, ip, port):
 
         # Parameters

--- a/src_python/org_agg.py
+++ b/src_python/org_agg.py
@@ -38,6 +38,7 @@ class Aggregator:
     """Aggregator
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, model, rounds, num_orgs, ip, port):
 
         # Parameters

--- a/src_python/org_server.py
+++ b/src_python/org_server.py
@@ -39,7 +39,7 @@ class Server:
     """Server
     """
 
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-positional-arguments
     def __init__(self, org_id, model_weights, rounds, num_clients, ip, port):
 
         # Parameters

--- a/src_python/org_server.py
+++ b/src_python/org_server.py
@@ -39,6 +39,7 @@ class Server:
     """Server
     """
 
+    #pylint: disable=too-many-arguments
     def __init__(self, org_id, model_weights, rounds, num_clients, ip, port):
 
         # Parameters


### PR DESCRIPTION
This PR fixes the lint error `R0917: Too many positional arguments (7/5) (too-many-positional-arguments)`