### PR TITLE
Add kafka to docker mode

### DIFF
--- a/conf/jasminegraph-server.properties
+++ b/conf/jasminegraph-server.properties
@@ -18,12 +18,12 @@
 #JasmineGraph specific parameters
 #--------------------------------------------------------------------------------
 #org.jasminegraph.server.host is where the master(server) of the JasmineGraph system runs.
-org.jasminegraph.server.host=localhost
+org.jasminegraph.server.host=172.28.5.1
 #Number of workers JasmineGraph cluster should use if it was not specified as a console argument
 org.jasminegraph.server.nworkers=2
 #org.jasminegraph.server.npartitions is the number of partitions into which the graph should be partitioned
 org.jasminegraph.server.npartitions=2
-org.jasminegraph.server.streaming.kafka.host=127.0.0.1:9092
+org.jasminegraph.server.streaming.kafka.host=172.28.5.4:9092
 org.jasminegraph.worker.path=/var/tmp/jasminegraph/
 #Path to keep jasminegraph artifacts in order to copy them to remote locations. If this is not set then the artifacts in the
 #JASMINEGRAPH_HOME location will be copied instead.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     command: --MODE 1 --MASTERIP 172.28.5.1 --WORKERS 2 --WORKERIP 172.28.5.1 --ENABLE_NMON false
     depends_on:
       - prometheus
+      - kafka
   prometheus:
     image: prom/prometheus:latest
     ports:
@@ -32,7 +33,14 @@ services:
       - 9091:9091
     networks:
       jasminenet:
-        ipv4_address: 172.28.5.3    
+        ipv4_address: 172.28.5.3
+  kafka:
+    image: apache/kafka:3.9.0
+    ports:
+      - 9092:9092
+    networks:
+      jasminenet:
+        ipv4_address: 172.28.5.4
 networks:
   jasminenet:
     external: false

--- a/stop-docker.sh
+++ b/stop-docker.sh
@@ -13,4 +13,4 @@ PORT="7777"
     sleep 5
 ) | telnet "$HOST" "$PORT"
 
-docker compose stop prometheus pushgateway &
+docker compose stop kafka prometheus pushgateway &


### PR DESCRIPTION
This PR will add a Kafka container to docker mode of JasmineGraph. This will enable ease of local testing of JasmineGraph's streaming features.