### PR TITLE
Support for both type of hosts (server@ip, ip)

### DIFF
--- a/src/util/Utils.cpp
+++ b/src/util/Utils.cpp
@@ -1320,7 +1320,7 @@ void Utils::assignPartitionToWorker(int graphId, int partitionIndex, string  hos
     auto *sqlite = new SQLiteDBInterface();
     sqlite->init();
 
-    string workerHost;
+    string workerHost = hostname;
     if (hostname.find('@') != std::string::npos) {
         workerHost = Utils::split(hostname, '@')[1];
     }


### PR DESCRIPTION
The previous version only supports assigning partitions to workers, only for workers who have a server@ip_address structure (for example, muthumala@10.8.100.245 ) their hostnames. Now that is extended to support hostnames which contain only an IP address (for example, 10.8.100.245)