### PR TITLE
Issue/kafka rmgr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - './env/data:/var/tmp/data'
       - '/tmp/jasminegraph:/tmp/jasminegraph'
       - '/var/tmp/jasminegraph:/var/tmp/jasminegraph'
-      - '/var/tmp/hdfs/filechunks: /var/tmp/hdfs/filechunks'
+      - '/var/tmp/hdfs/filechunks:/var/tmp/hdfs/filechunks'
 
     networks:
       - jasminenet

--- a/src/util/kafka/StreamHandler.cpp
+++ b/src/util/kafka/StreamHandler.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "../logger/Logger.h"
 #include "../Utils.h"
+#include "../../server/JasmineGraphServer.h"
 
 using json = nlohmann::json;
 using namespace std;
@@ -59,6 +60,15 @@ bool StreamHandler::isEndOfStream(const cppkafka::Message &msg) {
 }
 
 void StreamHandler::listen_to_kafka_topic() {
+    // get workers
+    JasmineGraphServer *server = JasmineGraphServer::getInstance();
+    std::vector<JasmineGraphServer::worker> workers = server->workers(workerClients.size());
+
+    // assign partitions to workers
+    for (int i = 0; i < workerClients.size(); i++) {
+        Utils::assignPartitionToWorker(graphId, i, workers.at(i).hostname, workers.at(i).port);
+    }
+
     while (true) {
         cppkafka::Message msg = this->pollMessage();
 


### PR DESCRIPTION
For graphs uploaded as kafka stream,  when deleting them, the files located in the Jasminegraph Nativestore are not deleted. Fix that issue.