### PR TITLE
fix for Unexpected response 'grap' instead of 'graphid-send' after executing train command via Telnet

### DIFF
--- a/src/frontend/JasmineGraphFrontEnd.cpp
+++ b/src/frontend/JasmineGraphFrontEnd.cpp
@@ -1600,7 +1600,7 @@ static void triangles_command(std::string masterIP, int connFd, SQLiteDBInterfac
                               PerformanceSQLiteDBInterface *perfSqlite, JobScheduler *jobScheduler, bool *loop_exit_p) {
     // add RDF graph
     int uniqueId = JasmineGraphFrontEndCommon::getUid();
-    int result_wr = write(connFd, GRAPHID_SEND.c_str(), FRONTEND_COMMAND_LENGTH);
+    int result_wr = write(connFd, GRAPHID_SEND.c_str(), GRAPHID_SEND.size());
     if (result_wr < 0) {
         frontend_logger.error("Error writing to socket");
         *loop_exit_p = true;

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -129,7 +129,7 @@ def test(host, port):
         print()
         logging.info('Testing trian')
         send_and_expect_response(sock, 'trian', TRIAN,
-                                 b'grap', exit_on_failure=True)
+                                 b'graphid-send', exit_on_failure=True)
         send_and_expect_response(
             sock, 'trian', b'1', b'priority(>=1)', exit_on_failure=True)
         send_and_expect_response(sock, 'trian', b'1', b'651')


### PR DESCRIPTION
Pull request consist of the fix for the issue raised [here](https://github.com/miyurud/jasminegraph/issues/300)