### PR TITLE
Added loki logging stack with docker-compose

### DIFF
--- a/loki/config.alloy
+++ b/loki/config.alloy
@@ -1,0 +1,47 @@
+// This component is responsible for disovering new containers within the docker environment
+discovery.docker "getting_started" {
+	host = "unix:///var/run/docker.sock"
+	refresh_interval = "5s"
+}
+
+// This component is responsible for relabeling the discovered containers
+discovery.relabel "getting_started" {
+	targets = []
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+// This component is responsible for collecting logs from the discovered containers
+loki.source.docker "getting_started" {
+	host             = "unix:///var/run/docker.sock"
+	targets          = discovery.docker.getting_started.targets
+	forward_to       = [loki.process.getting_started.receiver]
+	relabel_rules    = discovery.relabel.getting_started.rules
+	refresh_interval = "5s"
+}
+
+// This component is responsible for processing the logs (In this case adding static labels)
+loki.process "getting_started" {
+    stage.static_labels {
+    values = {
+      env = "production",
+    }
+}
+    forward_to = [loki.write.getting_started.receiver]
+}
+
+// This component is responsible for writing the logs to Loki
+loki.write "getting_started" {
+	endpoint {
+		url  = "http://loki:3100/loki/api/v1/push"
+	}
+}
+
+// Enables the ability to view logs in the Alloy UI in realtime
+livedebugging {
+  enabled = true
+}

--- a/loki/docker-compose.yaml
+++ b/loki/docker-compose.yaml
@@ -1,0 +1,63 @@
+version: '3'
+services:
+  alloy:
+    image: grafana/alloy:v1.7.5
+    ports:
+      - 12345:12345
+      - 4317:4317
+      - 4318:4318
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki
+    networks:
+      - loki
+  loki:
+    image: grafana/loki:3.4.2
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - loki
+  grafana:
+    image: grafana/grafana:11.6.0
+    environment:
+      - GF_FEATURE_TOGGLES_ENABLE=grafanaManagedRecordingRules
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: 'http://loki:3100'
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: true 
+        EOF
+        /run.sh
+    networks:
+      - loki
+
+networks:
+  loki:
+
+
+
+
+

--- a/loki/loki-config.yaml
+++ b/loki/loki-config.yaml
@@ -1,0 +1,63 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  metric_aggregation_enabled: true
+  allow_structured_metadata: true
+  volume_enabled: true
+  retention_period: 24h   # 24h
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+ruler:
+  enable_alertmanager_discovery: true
+  enable_api: true
+
+
+
+
+frontend:
+  encoding: protobuf
+
+
+compactor:
+  working_directory: /tmp/loki/retention
+  delete_request_store: filesystem
+  retention_enabled: true

--- a/run-loki.sh
+++ b/run-loki.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+SERVICE_DIR="./loki"
+
+PROJECT_NAME="grafana-loki"
+
+cd "$SERVICE_DIR" || { echo "Directory $SERVICE_DIR not found"; exit 1; }
+
+docker-compose -p "$PROJECT_NAME" up -d


### PR DESCRIPTION
## Summary

This PR adds a Docker Compose setup for Grafana Loki that collects logs from running Docker containers using Grafana Alloy. It also includes a helper script to start the logging stack easily.

## What's Included

- `docker-compose.yaml` with Grafana, Loki, and Grafana Alloy services
- Grafana Alloy configured to read logs from local Docker containers
- `run-loki.sh` script to launch the stack from the root directory

## How to Run

1. From the project root, run:
   ```bash
   ./run-loki.sh

2. Accsess the Grafana Dashboard at `http://localhost:3000/`
