### PR TITLE
Fix Kafka streaming connectivity in Docker mode with proper network configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,10 @@ services:
       - './env/data:/var/tmp/data'
       - '/tmp/jasminegraph:/tmp/jasminegraph'
       - '/var/tmp/jasminegraph:/var/tmp/jasminegraph'
+      - './conf:/home/ubuntu/software/jasminegraph/conf'
     networks:
-      - jasminenet
+      jasminenet:
+        ipv4_address: 172.28.5.5
     command: --MODE 1 --MASTERIP 172.28.5.1 --WORKERS 2 --WORKERIP 172.28.5.1 --ENABLE_NMON false
     depends_on:
       - prometheus
@@ -39,6 +41,20 @@ services:
     image: apache/kafka:3.9.0
     ports:
       - 9092:9092
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://172.28.5.4:9092,CONTROLLER://172.28.5.4:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://172.28.5.4:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@172.28.5.4:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_NUM_PARTITIONS: 3
+      CLUSTER_ID: ciWo7IWazngRchmPES6q5A==
     networks:
       jasminenet:
         ipv4_address: 172.28.5.4

--- a/src/frontend/JasmineGraphFrontEnd.cpp
+++ b/src/frontend/JasmineGraphFrontEnd.cpp
@@ -1266,7 +1266,7 @@ static void add_stream_kafka_command(int connFd, std::string &kafka_server_IP, c
     string group_id = "knnect";   // TODO(sakeerthan): MOVE TO CONSTANT LATER
     if (default_kafka == "y") {
         kafka_server_IP = Utils::getJasmineGraphProperty("org.jasminegraph.server.streaming.kafka.host");
-        configs = {{"metadata.broker.list", kafka_server_IP}, {"group.id", group_id}};
+        configs = {{"metadata.broker.list", kafka_server_IP}, {"group.id", group_id}, {"auto.offset.reset", "earliest"}};
     } else {
         // user need to start relevant kafka cluster using relevant IP address
         // read relevant IP address from given file path
@@ -1307,7 +1307,7 @@ static void add_stream_kafka_command(int connFd, std::string &kafka_server_IP, c
             }
         }
         //              set the config according to given IP address
-        configs = {{"metadata.broker.list", kafka_server_IP}, {"group.id", "knnect"}};
+        configs = {{"metadata.broker.list", kafka_server_IP}, {"group.id", "knnect"}, {"auto.offset.reset", "earliest"}};
     }
 
     frontend_logger.info("Start serving `" + ADD_STREAM_KAFKA + "` command");


### PR DESCRIPTION
This PR fixes the Kafka streaming functionality in Docker mode by addressing network connectivity issues between JasmineGraph and Kafka containers.

## Changes Made

### Docker Compose Configuration (`docker-compose.yml`)
- **Added comprehensive Kafka environment configuration** for KRaft mode
- **Configured static IP addresses** for all services in the `jasminenet` network:
  - JasmineGraph: `172.28.5.5`
  - Prometheus: `172.28.5.2` 
  - Pushgateway: `172.28.5.3`
  - Kafka: `172.28.5.4`
- **Fixed Kafka listeners configuration**:
  - `KAFKA_LISTENERS`: `PLAINTEXT://172.28.5.4:9092,CONTROLLER://172.28.5.4:9093`
  - `KAFKA_ADVERTISED_LISTENERS`: `PLAINTEXT://172.28.5.4:9092`
- **Configured KRaft mode** with proper controller and broker settings

### Frontend Configuration (`JasmineGraphFrontEnd.cpp`)
- **Added `auto.offset.reset=earliest`** to Kafka consumer configuration
- Ensures streaming consumers read from the beginning of topics when no previous offset exists
- Applied to both default and custom Kafka configuration paths
- Prevents message loss when consumers start fresh in Docker environment

## Issues Fixed
-  **Kafka listener binding**: Resolved 0.0.0.0 vs specific IP addressing issues  
-  **Consumer offset management**: Added proper offset reset behavior for new consumers
