### PR TITLE
Fix to print master and worker logs on all k8s integration-test failures

### DIFF
--- a/test-k8s.sh
+++ b/test-k8s.sh
@@ -275,7 +275,7 @@ timeout "$TIMEOUT_SECONDS" python3 -u "${TEST_ROOT}/test-k8s.py" "$masterIP" |& 
 exit_code="${PIPESTATUS[0]}"
 
 set +ex
-if [ "$exit_code" = '124' ]; then
+if [ "$exit_code" != '0' ]; then
     echo
     kubectl get pods -o wide
 


### PR DESCRIPTION
Currently, JasmineGraph integration tests only print master and worker logs when the test times out (exit_code=124). If the test fails due to other errors (non-zero exit code), logs are not printed.